### PR TITLE
Perseus34x/optimize comparisons

### DIFF
--- a/crates/rwasm/executor/src/executor.rs
+++ b/crates/rwasm/executor/src/executor.rs
@@ -925,14 +925,34 @@ impl<'a> Executor<'a> {
                     c: event.b,
                     code: cmp_ins.code(),
                 };
-                //if opcode == Opcode::I32LtS
+
                 {
                     println!("opcode {:?} : gt event:{:?}", opcode, gt_comp_event);
                     println!("opcode {:?} :lt event:{:?}", opcode, lt_comp_event);
                 }
 
-                self.record.lt_events.push(gt_comp_event);
-                self.record.lt_events.push(lt_comp_event);
+                match opcode {
+                    // Opcodes that only need a "less than" check.
+                    Opcode::I32LtS | Opcode::I32LtU => {
+                        self.record.lt_events.push(lt_comp_event);
+                    }
+                    // Opcodes that only need a "greater than" check.
+                    Opcode::I32GtS | Opcode::I32GtU => {
+                        self.record.lt_events.push(gt_comp_event);
+                    }
+                    // All other comparisons depend on equality, so they need both checks.
+                    Opcode::I32LeS |
+                    Opcode::I32LeU |
+                    Opcode::I32GeS |
+                    Opcode::I32GeU |
+                    Opcode::I32Eq |
+                    Opcode::I32Eqz |
+                    Opcode::I32Ne => {
+                        self.record.lt_events.push(gt_comp_event);
+                        self.record.lt_events.push(lt_comp_event);
+                    }
+                    _ => unreachable!(),
+                }
             }
             Opcode::I32Mul => {
                 self.record.mul_events.push(event);

--- a/crates/rwasm/executor/src/executor.rs
+++ b/crates/rwasm/executor/src/executor.rs
@@ -892,62 +892,55 @@ impl<'a> Executor<'a> {
                     opcode,
                     Opcode::I32GeS | Opcode::I32GtS | Opcode::I32LeS | Opcode::I32LtS
                 );
-                let arg1_lt_arg2 = if use_signed_comparison {
-                    (event.b as i32) < (event.c as i32)
-                } else {
-                    event.b < event.c
-                };
-                let arg1_gt_arg2 = if use_signed_comparison {
-                    (event.b as i32) > (event.c as i32)
-                } else {
-                    event.b > event.c
-                };
-                let cmp_ins = {
+
+                let (lt_res, gt_res, cmp_opcode) = {
                     if use_signed_comparison {
-                        Opcode::I32LtS
+                        (
+                            ((event.b as i32) < (event.c as i32)) as u32,
+                            ((event.b as i32) > (event.c as i32)) as u32,
+                            Opcode::I32LtS,
+                        )
                     } else {
-                        Opcode::I32LtU
+                        ((event.b < event.c) as u32, (event.b > event.c) as u32, Opcode::I32LtU)
                     }
                 };
+
                 let lt_comp_event = AluEvent {
                     pc: UNUSED_PC,
-                    opcode: cmp_ins,
-                    a: arg1_lt_arg2 as u32,
+                    opcode: cmp_opcode,
+                    a: lt_res,
                     b: event.b,
                     c: event.c,
-                    code: cmp_ins.code(),
+                    code: cmp_opcode.code(),
                 };
                 let gt_comp_event = AluEvent {
                     pc: UNUSED_PC,
-                    opcode: cmp_ins,
-                    a: arg1_gt_arg2 as u32,
+                    opcode: cmp_opcode,
+                    a: gt_res,
                     b: event.c,
                     c: event.b,
-                    code: cmp_ins.code(),
+                    code: cmp_opcode.code(),
                 };
-
-                {
-                    println!("opcode {:?} : gt event:{:?}", opcode, gt_comp_event);
-                    println!("opcode {:?} :lt event:{:?}", opcode, lt_comp_event);
-                }
 
                 match opcode {
                     // Opcodes that only need a "less than" check.
                     Opcode::I32LtS | Opcode::I32LtU => {
                         self.record.lt_events.push(lt_comp_event);
                     }
-                    // Opcodes that only need a "greater than" check.
+                    // b > c is equivalent to c < b
                     Opcode::I32GtS | Opcode::I32GtU => {
                         self.record.lt_events.push(gt_comp_event);
                     }
-                    // All other comparisons depend on equality, so they need both checks.
-                    Opcode::I32LeS |
-                    Opcode::I32LeU |
-                    Opcode::I32GeS |
-                    Opcode::I32GeU |
-                    Opcode::I32Eq |
-                    Opcode::I32Eqz |
-                    Opcode::I32Ne => {
+                    // b >= c is equivalent to !(b < c)
+                    Opcode::I32GeS | Opcode::I32GeU => {
+                        self.record.lt_events.push(AluEvent { a: 1 - gt_res, ..lt_comp_event });
+                    }
+                    // b <= c is equivalent to !(c < b)
+                    Opcode::I32LeS | Opcode::I32LeU => {
+                        self.record.lt_events.push(AluEvent { a: 1 - lt_res, ..gt_comp_event });
+                    }
+                    // Equality checks need to know if `b < c` and `c < b` are both false.
+                    Opcode::I32Eq | Opcode::I32Eqz | Opcode::I32Ne => {
                         self.record.lt_events.push(gt_comp_event);
                         self.record.lt_events.push(lt_comp_event);
                     }

--- a/crates/rwasm/machine/src/alu/lt/mod.rs
+++ b/crates/rwasm/machine/src/alu/lt/mod.rs
@@ -571,18 +571,18 @@ mod tests {
 
         prove_babybear_template(&mut shard);
     }
+
     #[test]
-    fn test_malicious_ltu() {
-        run_malicious_lt(Opcode::I32LtU)
-    }
-    #[test]
-    fn test_malicious_lts() {
-        run_malicious_lt(Opcode::I32LtS)
+    fn test_malicious_lt() {
+        for opcode in [Opcode::I32Eq, Opcode::I32LtS,Opcode::I32GtS,Opcode::I32LtU,Opcode::I32GtU,Opcode::I32LeS,Opcode::I32GeS,Opcode::I32LeU,Opcode::I32GeU] {
+            run_malicious_lt(opcode)
+        }
+
     }
 
     fn run_malicious_lt(opcode: Opcode) {
         use core::borrow::BorrowMut;
-        const NUM_TESTS: usize = 10;
+        const NUM_TESTS: usize = 2;
 
         let rng = thread_rng();
         for _ in 0..NUM_TESTS {
@@ -590,7 +590,16 @@ mod tests {
             let op_c = thread_rng().gen_range(0..u32::MAX);
 
             let correct_op_a =
-                if opcode == Opcode::I32LtU { op_b < op_c } else { (op_b as i32) < (op_c as i32) };
+                if opcode == Opcode::I32LtU { op_b < op_c }
+                else if opcode == Opcode::I32GtU { op_b > op_c }
+                else if opcode == Opcode::I32LeU { op_b <= op_c }
+                else if opcode == Opcode::I32GeU { op_b >= op_c }
+                else if opcode == Opcode::I32Eq { op_b == op_c }
+                else if opcode == Opcode::I32LtS { (op_b as i32) < (op_c as i32) }
+                else if opcode == Opcode::I32GtS { (op_b as i32) > (op_c as i32) }
+                else if opcode == Opcode::I32LeS { (op_b as i32) <= (op_c as i32) }
+                else if opcode == Opcode::I32GeS { (op_b as i32) >= (op_c as i32) }
+                else { true };
             //Pops rhs, then lhs, pushes i32( lhs <_s rhs ? 1 : 0 )
             let op_a = !correct_op_a;
             let program = Program::from_instrs(vec![
@@ -628,6 +637,7 @@ mod tests {
             let result =
                 run_malicious_test::<P>(program, stdin, Box::new(malicious_trace_pv_generator));
             let chip_name = chip_name!(CpuChip, BabyBear);
+            println!("run_malicious_lt for opcode : {:?}", opcode);
             assert!(result.is_err());
             assert!(result.unwrap_err().is_constraints_failing(&chip_name));
         }

--- a/crates/rwasm/machine/src/alu/lt/mod.rs
+++ b/crates/rwasm/machine/src/alu/lt/mod.rs
@@ -474,7 +474,7 @@ mod tests {
     use crate::{
         alu::LtCols,
         io::SP1Stdin,
-        rwasm::RwasmAir,
+        rwasm::{CpuChip, RwasmAir},
         utils::{run_malicious_test, uni_stark_prove as prove, uni_stark_verify as verify},
     };
     use p3_baby_bear::BabyBear;
@@ -577,7 +577,6 @@ mod tests {
     }
     #[test]
     fn test_malicious_lts() {
-        //TODO it is failed!
         run_malicious_lt(Opcode::I32LtS)
     }
 
@@ -595,8 +594,8 @@ mod tests {
             //Pops rhs, then lhs, pushes i32( lhs <_s rhs ? 1 : 0 )
             let op_a = !correct_op_a;
             let program = Program::from_instrs(vec![
-                Opcode::I32Const(op_c.into()),
                 Opcode::I32Const(op_b.into()),
+                Opcode::I32Const(op_c.into()),
                 opcode,
             ]);
             let stdin = SP1Stdin::new();
@@ -628,11 +627,9 @@ mod tests {
 
             let result =
                 run_malicious_test::<P>(program, stdin, Box::new(malicious_trace_pv_generator));
-            let lt_chip_name = chip_name!(LtChip, BabyBear);
+            let chip_name = chip_name!(CpuChip, BabyBear);
             assert!(result.is_err());
-            println!("mytest op_a={} op_b={}, op_b={}", op_a, op_b, op_c);
-            println!("{:?}", result);
-            assert!(result.unwrap_err().is_constraints_failing(&lt_chip_name));
+            assert!(result.unwrap_err().is_constraints_failing(&chip_name));
         }
     }
 }

--- a/crates/rwasm/machine/src/alu/lt/mod.rs
+++ b/crates/rwasm/machine/src/alu/lt/mod.rs
@@ -574,10 +574,19 @@ mod tests {
 
     #[test]
     fn test_malicious_lt() {
-        for opcode in [Opcode::I32Eq, Opcode::I32LtS,Opcode::I32GtS,Opcode::I32LtU,Opcode::I32GtU,Opcode::I32LeS,Opcode::I32GeS,Opcode::I32LeU,Opcode::I32GeU] {
+        for opcode in [
+            Opcode::I32Eq,
+            Opcode::I32LtS,
+            Opcode::I32GtS,
+            Opcode::I32LtU,
+            Opcode::I32GtU,
+            Opcode::I32LeS,
+            Opcode::I32GeS,
+            Opcode::I32LeU,
+            Opcode::I32GeU,
+        ] {
             run_malicious_lt(opcode)
         }
-
     }
 
     fn run_malicious_lt(opcode: Opcode) {
@@ -589,17 +598,27 @@ mod tests {
             let op_b = thread_rng().gen_range(0..u32::MAX);
             let op_c = thread_rng().gen_range(0..u32::MAX);
 
-            let correct_op_a =
-                if opcode == Opcode::I32LtU { op_b < op_c }
-                else if opcode == Opcode::I32GtU { op_b > op_c }
-                else if opcode == Opcode::I32LeU { op_b <= op_c }
-                else if opcode == Opcode::I32GeU { op_b >= op_c }
-                else if opcode == Opcode::I32Eq { op_b == op_c }
-                else if opcode == Opcode::I32LtS { (op_b as i32) < (op_c as i32) }
-                else if opcode == Opcode::I32GtS { (op_b as i32) > (op_c as i32) }
-                else if opcode == Opcode::I32LeS { (op_b as i32) <= (op_c as i32) }
-                else if opcode == Opcode::I32GeS { (op_b as i32) >= (op_c as i32) }
-                else { true };
+            let correct_op_a = if opcode == Opcode::I32LtU {
+                op_b < op_c
+            } else if opcode == Opcode::I32GtU {
+                op_b > op_c
+            } else if opcode == Opcode::I32LeU {
+                op_b <= op_c
+            } else if opcode == Opcode::I32GeU {
+                op_b >= op_c
+            } else if opcode == Opcode::I32Eq {
+                op_b == op_c
+            } else if opcode == Opcode::I32LtS {
+                (op_b as i32) < (op_c as i32)
+            } else if opcode == Opcode::I32GtS {
+                (op_b as i32) > (op_c as i32)
+            } else if opcode == Opcode::I32LeS {
+                (op_b as i32) <= (op_c as i32)
+            } else if opcode == Opcode::I32GeS {
+                (op_b as i32) >= (op_c as i32)
+            } else {
+                true
+            };
             //Pops rhs, then lhs, pushes i32( lhs <_s rhs ? 1 : 0 )
             let op_a = !correct_op_a;
             let program = Program::from_instrs(vec![

--- a/crates/rwasm/machine/src/cpu/air/mod.rs
+++ b/crates/rwasm/machine/src/cpu/air/mod.rs
@@ -19,7 +19,6 @@ use crate::{
     memory::StackAddressCols,
 };
 use rwasm_executor::UNUSED_PC;
-use sp1_stark::air::InstructionAirBuilder;
 
 impl<AB> Air<AB> for CpuChip
 where
@@ -180,13 +179,13 @@ impl CpuChip {
 
         // Create flags to determine which checks are necessary based on the opcode.
         // A `lt` check is needed for all comparisons except `gt` and `le`.
-        let needs_lt_check = is_comparison.clone() -
+        let needs_lt_check = is_comparison -
             (local.instruction.is_i32gts +
                 local.instruction.is_i32gtu +
                 local.instruction.is_i32les +
                 local.instruction.is_i32leu);
         // A `gt` check is needed for all comparisons except `lt` and `ge`.
-        let needs_gt_check = is_comparison.clone() -
+        let needs_gt_check = is_comparison -
             (local.instruction.is_i32lts +
                 local.instruction.is_i32ltu +
                 local.instruction.is_i32ges +

--- a/crates/rwasm/machine/src/cpu/air/mod.rs
+++ b/crates/rwasm/machine/src/cpu/air/mod.rs
@@ -159,17 +159,17 @@ impl CpuChip {
         builder
             .when(local.instruction.is_i32lts + local.instruction.is_i32ltu)
             .assert_eq(local.alu_cols.res_bool, local.alu_cols.arg1_lt_arg2);
-        builder.when(local.instruction.is_i32les + local.instruction.is_i32leu).assert_eq(
-            local.alu_cols.res_bool,
-            local.alu_cols.arg1_eq_arg2 + local.alu_cols.arg1_lt_arg2,
-        );
         builder
             .when(local.instruction.is_i32gts + local.instruction.is_i32gtu)
             .assert_eq(local.alu_cols.res_bool, local.alu_cols.arg1_gt_arg2);
-        builder.when(local.instruction.is_i32ges + local.instruction.is_i32geu).assert_eq(
-            local.alu_cols.res_bool,
-            local.alu_cols.arg1_eq_arg2 + local.alu_cols.arg1_gt_arg2,
-        );
+
+        builder
+            .when(local.instruction.is_i32les + local.instruction.is_i32leu)
+            .assert_eq(local.alu_cols.res_bool, AB::Expr::one() - local.alu_cols.arg1_gt_arg2);
+
+        builder
+            .when(local.instruction.is_i32ges + local.instruction.is_i32geu)
+            .assert_eq(local.alu_cols.res_bool, AB::Expr::one() - local.alu_cols.arg1_lt_arg2);
         builder
             .when(local.instruction.is_i32ne)
             .assert_eq(AB::Expr::one() - local.alu_cols.res_bool, local.alu_cols.arg1_eq_arg2);
@@ -179,10 +179,18 @@ impl CpuChip {
         builder.when(local.instruction.is_i32eqz).assert_word_zero(local.op_arg2_val());
 
         // Create flags to determine which checks are necessary based on the opcode.
-        let needs_lt_check =
-            is_comparison.clone() - local.instruction.is_i32gts - local.instruction.is_i32gtu;
-        let needs_gt_check =
-            is_comparison.clone() - local.instruction.is_i32lts - local.instruction.is_i32ltu;
+        // A `lt` check is needed for all comparisons except `gt` and `le`.
+        let needs_lt_check = is_comparison.clone() -
+            (local.instruction.is_i32gts +
+                local.instruction.is_i32gtu +
+                local.instruction.is_i32les +
+                local.instruction.is_i32leu);
+        // A `gt` check is needed for all comparisons except `lt` and `ge`.
+        let needs_gt_check = is_comparison.clone() -
+            (local.instruction.is_i32lts +
+                local.instruction.is_i32ltu +
+                local.instruction.is_i32ges +
+                local.instruction.is_i32geu);
 
         let cmp_ins_expr = use_signed_comparison.clone() *
             AB::Expr::from_canonical_u32(Opcode::I32LtS.code()) +

--- a/crates/rwasm/machine/src/cpu/air/mod.rs
+++ b/crates/rwasm/machine/src/cpu/air/mod.rs
@@ -19,6 +19,8 @@ use crate::{
     memory::StackAddressCols,
 };
 use rwasm_executor::UNUSED_PC;
+use sp1_stark::air::InstructionAirBuilder;
+
 impl<AB> Air<AB> for CpuChip
 where
     AB: SP1CoreAirBuilder + AirBuilderWithPublicValues,
@@ -175,41 +177,50 @@ impl CpuChip {
             .when(local.instruction.is_i32eqz + local.instruction.is_i32eq)
             .assert_eq(local.alu_cols.res_bool, local.alu_cols.arg1_eq_arg2);
         builder.when(local.instruction.is_i32eqz).assert_word_zero(local.op_arg2_val());
-        // Send to the ALU table to verify correct calculation of addr_word.
+
+        // Create flags to determine which checks are necessary based on the opcode.
+        let needs_lt_check =
+            is_comparison.clone() - local.instruction.is_i32gts - local.instruction.is_i32gtu;
+        let needs_gt_check =
+            is_comparison.clone() - local.instruction.is_i32lts - local.instruction.is_i32ltu;
+
+        let cmp_ins_expr = use_signed_comparison.clone() *
+            AB::Expr::from_canonical_u32(Opcode::I32LtS.code()) +
+            (AB::Expr::one() - use_signed_comparison.clone()) *
+                AB::Expr::from_canonical_u32(Opcode::I32LtU.code());
+
+        // Conditionally send the `lt` check to the ALU table.
         builder.send_instruction(
             AB::Expr::zero(),
             AB::Expr::zero(),
             AB::Expr::from_canonical_u32(UNUSED_PC),
             AB::Expr::from_canonical_u32(UNUSED_PC + DEFAULT_PC_INC),
             AB::Expr::zero(),
-            use_signed_comparison.clone() * AB::Expr::from_canonical_u32(Opcode::I32LtS.code()) +
-                (AB::Expr::one() - use_signed_comparison.clone()) *
-                    AB::Expr::from_canonical_u32(Opcode::I32LtU.code()),
+            cmp_ins_expr.clone(),
             Word::extend_var::<AB>(comparison_alu.arg1_lt_arg2),
             local.op_arg1_val(),
             local.op_arg2_val(),
             AB::Expr::zero(),
             AB::Expr::zero(),
             AB::Expr::zero(),
-            is_comparison,
+            needs_lt_check,
         );
 
+        // Conditionally send the `gt` check to the ALU table.
         builder.send_instruction(
             AB::Expr::zero(),
             AB::Expr::zero(),
             AB::Expr::from_canonical_u32(UNUSED_PC),
             AB::Expr::from_canonical_u32(UNUSED_PC + DEFAULT_PC_INC),
             AB::Expr::zero(),
-            use_signed_comparison.clone() * AB::Expr::from_canonical_u32(Opcode::I32LtS.code()) +
-                (AB::Expr::one() - use_signed_comparison.clone()) *
-                    AB::Expr::from_canonical_u32(Opcode::I32LtU.code()),
+            cmp_ins_expr.clone(),
             Word::extend_var::<AB>(comparison_alu.arg1_gt_arg2),
-            local.op_arg2_val(),
+            local.op_arg2_val(), // Operands swapped to check `arg2 < arg1`
             local.op_arg1_val(),
             AB::Expr::zero(),
             AB::Expr::zero(),
             AB::Expr::zero(),
-            is_comparison,
+            needs_gt_check,
         );
     }
 

--- a/crates/rwasm/prover/src/rwasmtest/comp.rs
+++ b/crates/rwasm/prover/src/rwasmtest/comp.rs
@@ -2,7 +2,7 @@ use crate::rwasmtest::run_rwasm_prover;
 use rwasm_executor::{Opcode, Program};
 
 #[test]
-fn test_comparison_eq() {
+fn test_comparison_x_eq() {
     let x_value: u32 = 0x11;
     let y_value: u32 = 0x23;
     let z1_value: u32 = 0x3;
@@ -10,8 +10,12 @@ fn test_comparison_eq() {
         Opcode::I32Const(x_value.into()),
         Opcode::I32Const(y_value.into()),
         Opcode::I32Const(z1_value.into()),
+        Opcode::I32Const(x_value.into()),
+        Opcode::I32Const(y_value.into()),
         Opcode::I32GeU,
+        Opcode::I32GeS,
         Opcode::I32LeU,
+        Opcode::I32LeS,
     ];
     let program = Program::from_instrs(instructions);
     run_rwasm_prover(program);
@@ -43,6 +47,24 @@ fn test_comparison_gtu() {
         Opcode::I32Const(z1_value.into()),
         Opcode::I32GtU,
         Opcode::I32LtU,
+    ];
+    let program = Program::from_instrs(instructions);
+    run_rwasm_prover(program);
+}
+
+#[test]
+fn test_comparison_eq() {
+    let x_value: u32 = 0x11;
+    let y_value: u32 = 0x23;
+    let z1_value: u32 = 0x3;
+    let instructions = vec![
+        Opcode::I32Const(x_value.into()),
+        Opcode::I32Const(y_value.into()),
+        Opcode::I32Const(z1_value.into()),
+        Opcode::I32Const(x_value.into()),
+        Opcode::I32Eq,
+        Opcode::I32Ne,
+        Opcode::I32Eqz,
     ];
     let program = Program::from_instrs(instructions);
     run_rwasm_prover(program);

--- a/crates/rwasm/prover/src/rwasmtest/comp.rs
+++ b/crates/rwasm/prover/src/rwasmtest/comp.rs
@@ -1,0 +1,49 @@
+use crate::rwasmtest::run_rwasm_prover;
+use rwasm_executor::{Opcode, Program};
+
+#[test]
+fn test_comparison_eq() {
+    let x_value: u32 = 0x11;
+    let y_value: u32 = 0x23;
+    let z1_value: u32 = 0x3;
+    let instructions = vec![
+        Opcode::I32Const(x_value.into()),
+        Opcode::I32Const(y_value.into()),
+        Opcode::I32Const(z1_value.into()),
+        Opcode::I32GeU,
+        Opcode::I32LeU,
+    ];
+    let program = Program::from_instrs(instructions);
+    run_rwasm_prover(program);
+}
+#[test]
+fn test_comparison_gts() {
+    let x_value: u32 = 0x11;
+    let y_value: u32 = 0x23;
+    let z1_value: u32 = 0x3;
+    let instructions = vec![
+        Opcode::I32Const(x_value.into()),
+        Opcode::I32Const(y_value.into()),
+        Opcode::I32Const(z1_value.into()),
+        Opcode::I32GtS,
+        Opcode::I32LtS,
+    ];
+    let program = Program::from_instrs(instructions);
+    run_rwasm_prover(program);
+}
+
+#[test]
+fn test_comparison_gtu() {
+    let x_value: u32 = 0x11;
+    let y_value: u32 = 0x23;
+    let z1_value: u32 = 0x3;
+    let instructions = vec![
+        Opcode::I32Const(x_value.into()),
+        Opcode::I32Const(y_value.into()),
+        Opcode::I32Const(z1_value.into()),
+        Opcode::I32GtU,
+        Opcode::I32LtU,
+    ];
+    let program = Program::from_instrs(instructions);
+    run_rwasm_prover(program);
+}

--- a/crates/rwasm/prover/src/rwasmtest/mod.rs
+++ b/crates/rwasm/prover/src/rwasmtest/mod.rs
@@ -1,5 +1,5 @@
+mod comp;
 mod table_init;
-
 use rwasm_executor::Program;
 use rwasm_machine::utils::setup_logger;
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

I have now made the logic for comparing numbers more efficiently. Previously, comparisons were more expensive because they always ran two "less than" checks (both a < b and b < a`).

## Solution

-  The updated logic only runs the specific checks needed for the operation. 
- "Less than" (`lt`) now only runs one check. "Greater than" (`gt`) also uses just one check by swapping the numbers and reusing the "less than" logic. 
- Only the operations that rely on equality (like `le, eq, ne`) still use both checks, as this is how they figure out if `a == b. 
- This change removes unnecessary steps, reduces the system's execution log, and hence is more efficient for proof generation.

## PR Checklist

- [ X ] Added Tests
- [ ] Added Documentation
- [ X ] Breaking changes

