### PR TITLE
feat(alu/rotate): add RotateChip for i32.rotl / i32.rotr with OR-of-s…

### DIFF
--- a/crates/rwasm/executor/src/air.rs
+++ b/crates/rwasm/executor/src/air.rs
@@ -145,6 +145,10 @@ pub enum RwasmAirId {
     Call = 45,
 
     Table = 46,
+
+    /// The rotated left/right chip.
+    #[subenum(CoreAirId)]
+    Rotate = 47,
 }
 
 impl RwasmAirId {
@@ -159,6 +163,7 @@ impl RwasmAirId {
             RwasmAirId::ShiftLeft,
             RwasmAirId::ShiftRight,
             RwasmAirId::DivRem,
+            RwasmAirId::Rotate,
             RwasmAirId::Lt,
             RwasmAirId::Auipc,
             RwasmAirId::MemoryLocal,

--- a/crates/rwasm/executor/src/artifacts/rv32im_costs.json
+++ b/crates/rwasm/executor/src/artifacts/rv32im_costs.json
@@ -45,5 +45,6 @@
   "ShaCompress": 506,
   "MemoryInstrs": 93,
   "Secp256k1DoubleAssign": 4564,
-  "Table": 10000
+  "Table": 10000,
+  "Rotate": 256
 }

--- a/crates/rwasm/executor/src/executor.rs
+++ b/crates/rwasm/executor/src/executor.rs
@@ -955,7 +955,7 @@ impl<'a> Executor<'a> {
                 emit_divrem_dependencies(self, event);
             }
             Opcode::I32Rotl | Opcode::I32Rotr => {
-                todo!();
+                self.record.rotate_events.push(event);
             }
             _ => unreachable!(),
         }
@@ -5014,5 +5014,64 @@ mod tests {
         let mut rt = Executor::new(program, SP1CoreOpts::default());
         rt.run().unwrap();
         assert_eq!(rt.state.memory.get(rt.state.sp).unwrap().value, 1);
+    }
+
+    #[test]
+    fn test_i32rotl_masks_and_rotates() {
+        // Ensure ROTL masks the shift by 31 and rotates correctly.
+        let b: u32 = 0x2121_2121u32;
+        let c: u32 = 0xffff_ffefu32; // masks to 15
+        let expected: u32 = b.rotate_left(c & 31);
+
+        let program = Program::from_instrs(vec![
+            Opcode::I32Const(b.into()),
+            Opcode::I32Const(c.into()),
+            Opcode::I32Rotl,
+        ]);
+
+        let mut rt = Executor::new(program, SP1CoreOpts::default());
+        rt.run().unwrap();
+
+        let top = rt.state.memory.get(rt.state.sp).unwrap().value;
+        assert_eq!(top, expected, "I32Rotl result mismatch (masking or rotation incorrect)");
+    }
+
+    #[test]
+    fn test_i32rotr_basic() {
+        // Basic ROTR by 1: 0x8000_0001 -> 0xC000_0000 (but we check via rotate_right to avoid
+        // literal mistakes)
+        let b: u32 = 0x8000_0001u32;
+        let c: u32 = 1u32;
+        let expected: u32 = b.rotate_right(c & 31);
+
+        let program = Program::from_instrs(vec![
+            Opcode::I32Const(b.into()),
+            Opcode::I32Const(c.into()),
+            Opcode::I32Rotr,
+        ]);
+
+        let mut rt = Executor::new(program, SP1CoreOpts::default());
+        rt.run().unwrap();
+
+        let top = rt.state.memory.get(rt.state.sp).unwrap().value;
+        assert_eq!(top, expected, "I32Rotr result mismatch");
+    }
+    #[test]
+    fn test_i32rot() {
+        let b: u32 = 0x8000_0001u32;
+        let c: u32 = 7u32;
+        let program = Program::from_instrs(vec![
+            Opcode::I32Const(b.into()),
+            Opcode::I32Const(c.into()),
+            Opcode::I32Rotr,
+            Opcode::I32Const(c.into()),
+            Opcode::I32Rotl,
+        ]);
+
+        let mut rt = Executor::new(program, SP1CoreOpts::default());
+        rt.run().unwrap();
+
+        let top = rt.state.memory.get(rt.state.sp).unwrap().value;
+        assert_eq!(top, b, "recovery result mismatch");
     }
 }

--- a/crates/rwasm/executor/src/record.rs
+++ b/crates/rwasm/executor/src/record.rs
@@ -47,6 +47,8 @@ pub struct ExecutionRecord {
     pub divrem_events: Vec<AluEvent>,
     /// A trace of the SLT, SLTI, SLTU, and SLTIU events.
     pub lt_events: Vec<AluEvent>,
+    /// A trace of the Rotl, Rotr events.
+    pub rotate_events: Vec<AluEvent>,
     /// A trace of the memory opcodes.
     pub memory_instr_events: Vec<MemInstrEvent>,
 

--- a/crates/rwasm/machine/src/alu/mod.rs
+++ b/crates/rwasm/machine/src/alu/mod.rs
@@ -3,13 +3,14 @@ pub mod bitwise;
 pub mod divrem;
 pub mod lt;
 pub mod mul;
+pub mod rotate;
 pub mod sll;
 pub mod sr;
-
 pub use add_sub::*;
 pub use bitwise::*;
 pub use divrem::*;
 pub use lt::*;
 pub use mul::*;
+pub use rotate::*;
 pub use sll::*;
 pub use sr::*;

--- a/crates/rwasm/machine/src/alu/rotate/mod.rs
+++ b/crates/rwasm/machine/src/alu/rotate/mod.rs
@@ -1,0 +1,586 @@
+use core::borrow::{Borrow, BorrowMut};
+
+use hashbrown::HashMap;
+use p3_air::{Air, AirBuilder, BaseAir};
+use p3_field::{AbstractField, PrimeField, PrimeField32};
+use p3_matrix::{dense::RowMajorMatrix, Matrix};
+use p3_maybe_rayon::prelude::{ParallelIterator, ParallelSlice};
+use rwasm_executor::{
+    events::{AluEvent, ByteLookupEvent, ByteRecord},
+    ByteOpcode, ExecutionRecord, Opcode, Program, DEFAULT_PC_INC, UNUSED_PC,
+};
+use sp1_derive::AlignedBorrow;
+use sp1_stark::{air::MachineAir, Word};
+
+use crate::{air::SP1CoreAirBuilder, utils::pad_rows_fixed};
+
+/// The number of columns in the RotateChip.
+pub const NUM_ROTATE_COLS: usize = size_of::<RotateCols<u8>>();
+
+/// The column layout for the RotateChip.
+#[derive(AlignedBorrow, Default, Debug, Clone, Copy)]
+#[repr(C)]
+pub struct RotateCols<T> {
+    /// The program counter.
+    pub pc: T,
+    /// The final result of the rotation.
+    pub a: Word<T>,
+    /// The 32-bit value to be rotated.
+    pub b: Word<T>,
+    /// The 32-bit rotation amount.
+    pub c: Word<T>,
+
+    /// The rotation amount, masked to 5 bits (c & 0x1F).
+    pub c_masked: Word<T>,
+    /// The inverse rotation amount for the left shift (32 - c_masked).
+    pub c_inverse: Word<T>,
+
+    /// The result of the right shift (contribution from the right side).
+    pub right_shifted: Word<T>,
+    /// The result of the left shift (contribution from the left side).
+    pub left_shifted: Word<T>,
+
+    /// Instruction flag: set to 1 if the instruction is I32Rotr.
+    pub is_rotr: T,
+    /// Instruction flag: set to 1 if the instruction is I32Rotl.
+    pub is_rotl: T,
+}
+
+/// A chip that implements alu operations for the opcodes I32Rotl and I32Rotr.
+#[derive(Default)]
+pub struct RotateChip;
+
+impl RotateChip {
+    /// Create a row from an event.
+    fn event_to_row<F: PrimeField>(
+        &self,
+        event: &AluEvent,
+        cols: &mut RotateCols<F>,
+        blu: &mut impl ByteRecord,
+    ) {
+        cols.pc = F::from_canonical_u32(event.pc);
+
+        cols.a = Word::from(event.a);
+        cols.b = Word::from(event.b);
+        cols.c = Word::from(event.c);
+
+        let k = (event.c & 31) as u32; // mask to 5 bits
+        let inv = ((32 - k) & 31) as u32;
+        cols.c_masked = Word::from(k);
+        cols.c_inverse = Word::from(inv);
+
+        // Flags
+        cols.is_rotl = F::from_bool(event.code == Opcode::I32Rotl.code());
+        cols.is_rotr = F::from_bool(event.code == Opcode::I32Rotr.code());
+
+        // Compute the two contributing words such that: a = left_shifted OR right_shifted
+        // For ROTR(k): left = b << (32 - k), right = b >> k
+        // For ROTL(k): left = b >> (32 - k), right = b << k
+        let (left_bytes, right_bytes) = if event.code == Opcode::I32Rotl.code() {
+            (
+                event.b.wrapping_shr(inv).to_le_bytes(), // b >> (32 - k)
+                event.b.wrapping_shl(k).to_le_bytes(),   // b << k
+            )
+        } else {
+            (
+                event.b.wrapping_shl(inv).to_le_bytes(), // b << (32 - k)
+                event.b.wrapping_shr(k).to_le_bytes(),   // b >> k
+            )
+        };
+
+        cols.left_shifted = Word(left_bytes.map(F::from_canonical_u8));
+        cols.right_shifted = Word(right_bytes.map(F::from_canonical_u8));
+
+        // Add byte lookups to assert: a = left_shifted OR right_shifted
+        for ((a_b, l_b), r_b) in event.a.to_le_bytes().into_iter().zip(left_bytes).zip(right_bytes)
+        {
+            let byte_event =
+                ByteLookupEvent { opcode: ByteOpcode::OR, a1: a_b as u16, a2: 0, b: l_b, c: r_b };
+            blu.add_byte_lookup_event(byte_event);
+        }
+
+        // Range checks for helper words
+        blu.add_u8_range_checks(&left_bytes);
+        blu.add_u8_range_checks(&right_bytes);
+    }
+}
+
+impl<AB> Air<AB> for RotateChip
+where
+    AB: SP1CoreAirBuilder,
+{
+    fn eval(&self, builder: &mut AB) {
+        let main = builder.main();
+        let local = main.row_slice(0);
+        let local: &RotateCols<AB::Var> = (*local).borrow();
+
+        // One-hot for opcode flags
+        let is_real = local.is_rotl + local.is_rotr;
+
+        // Flags must be boolean and mutually exclusive (their sum is boolean).
+        builder.assert_bool(local.is_rotl);
+        builder.assert_bool(local.is_rotr);
+        builder.assert_bool(is_real.clone());
+
+        // Constrain `c_masked[0] + c_inverse[0]` to be either 0 or 32.
+        let sum = local.c_masked[0] + local.c_inverse[0];
+        let thirty_two = AB::Expr::from_canonical_u32(32);
+        builder.when(is_real.clone()).assert_zero(sum.clone() * (sum.clone() - thirty_two));
+
+        // Enforce a = left_shifted OR right_shifted (byte-wise).
+        let or_opcode = ByteOpcode::OR.as_field::<AB::F>();
+        for i in 0..4 {
+            builder.send_byte(
+                or_opcode,
+                local.a[i],
+                local.left_shifted[i],
+                local.right_shifted[i],
+                is_real.clone(),
+            );
+        }
+
+        // Ensure the two contributions do not overlap: (left & right) == 0 byte-wise.
+        let and_opcode = ByteOpcode::AND.as_field::<AB::F>();
+        let zero = AB::Expr::zero();
+        for i in 0..4 {
+            builder.send_byte(
+                and_opcode,
+                zero.clone(), // AND output must be 0
+                local.left_shifted[i],
+                local.right_shifted[i],
+                is_real.clone(),
+            );
+        }
+
+        // Constrain c_masked = c & 0x1F on the least-significant byte, and higher bytes are zero.
+        let mask_0x1f = AB::Expr::from_canonical_u8(0x1f);
+        builder.send_byte(
+            and_opcode,
+            local.c_masked[0],
+            local.c[0],
+            mask_0x1f.clone(),
+            is_real.clone(),
+        );
+        for i in 1..4 {
+            builder.when(is_real.clone()).assert_zero(local.c_masked[i]);
+        }
+
+        // Constrain c_inverse to be a 5-bit quantity as well.
+        builder.send_byte(
+            and_opcode,
+            local.c_inverse[0],
+            local.c_inverse[0],
+            mask_0x1f,
+            is_real.clone(),
+        );
+        for i in 1..4 {
+            builder.when(is_real.clone()).assert_zero(local.c_inverse[i]);
+        }
+
+        // Constrain the shift operations by sending them to the ALU bus.
+        let shr_opcode = AB::Expr::from_canonical_u32(Opcode::I32ShrU.code());
+        let shl_opcode = AB::Expr::from_canonical_u32(Opcode::I32Shl.code());
+
+        // For ROTL(b, k), we depend on `b << k` and `b >> (32 - k)`
+        builder.send_instruction(
+            AB::Expr::zero(),
+            AB::Expr::zero(),
+            AB::Expr::from_canonical_u32(UNUSED_PC),
+            AB::Expr::from_canonical_u32(UNUSED_PC + DEFAULT_PC_INC),
+            AB::Expr::zero(),
+            shl_opcode.clone(),
+            local.right_shifted,
+            local.b,
+            local.c_masked,
+            AB::Expr::zero(),
+            AB::Expr::zero(),
+            AB::Expr::zero(),
+            local.is_rotl,
+        );
+        builder.send_instruction(
+            AB::Expr::zero(),
+            AB::Expr::zero(),
+            AB::Expr::from_canonical_u32(UNUSED_PC),
+            AB::Expr::from_canonical_u32(UNUSED_PC + DEFAULT_PC_INC),
+            AB::Expr::zero(),
+            shr_opcode.clone(),
+            local.left_shifted,
+            local.b,
+            local.c_inverse,
+            AB::Expr::zero(),
+            AB::Expr::zero(),
+            AB::Expr::zero(),
+            local.is_rotl,
+        );
+
+        // For ROTR(b, k), we depend on `b >> k` and `b << (32 - k)`
+        builder.send_instruction(
+            AB::Expr::zero(),
+            AB::Expr::zero(),
+            AB::Expr::from_canonical_u32(UNUSED_PC),
+            AB::Expr::from_canonical_u32(UNUSED_PC + DEFAULT_PC_INC),
+            AB::Expr::zero(),
+            shr_opcode.clone(),
+            local.right_shifted,
+            local.b,
+            local.c_masked,
+            AB::Expr::zero(),
+            AB::Expr::zero(),
+            AB::Expr::zero(),
+            local.is_rotr,
+        );
+        builder.send_instruction(
+            AB::Expr::zero(),
+            AB::Expr::zero(),
+            AB::Expr::from_canonical_u32(UNUSED_PC),
+            AB::Expr::from_canonical_u32(UNUSED_PC + DEFAULT_PC_INC),
+            AB::Expr::zero(),
+            shl_opcode.clone(),
+            local.left_shifted,
+            local.b,
+            local.c_inverse,
+            AB::Expr::zero(),
+            AB::Expr::zero(),
+            AB::Expr::zero(),
+            local.is_rotr,
+        );
+
+        // Receive the main rotate instruction from the CPU bus.
+        let is_rot_op = local.is_rotl * AB::Expr::from_canonical_u32(Opcode::I32Rotl.code()) +
+            local.is_rotr * AB::Expr::from_canonical_u32(Opcode::I32Rotr.code());
+
+        builder.receive_instruction(
+            AB::Expr::zero(),
+            AB::Expr::zero(),
+            local.pc,
+            local.pc + AB::Expr::from_canonical_u32(DEFAULT_PC_INC),
+            AB::Expr::zero(),
+            is_rot_op,
+            local.a,
+            local.b,
+            local.c,
+            AB::Expr::zero(),
+            AB::Expr::zero(),
+            AB::Expr::zero(),
+            is_real,
+        );
+    }
+}
+impl<F> BaseAir<F> for RotateChip {
+    fn width(&self) -> usize {
+        NUM_ROTATE_COLS
+    }
+}
+impl<F: PrimeField32> MachineAir<F> for RotateChip {
+    type Record = ExecutionRecord;
+
+    type Program = Program;
+
+    fn name(&self) -> String {
+        "Rotate".to_string()
+    }
+
+    fn generate_dependencies(&self, input: &Self::Record, output: &mut Self::Record) {
+        let chunk_size = core::cmp::max(input.rotate_events.len() / num_cpus::get(), 1);
+
+        let collected_deps: Vec<_> = input
+            .rotate_events
+            .par_chunks(chunk_size)
+            .map(|events| {
+                let mut blu: HashMap<ByteLookupEvent, usize> = HashMap::new();
+                let mut sl_events = Vec::new();
+                let mut sr_events = Vec::new();
+
+                for event in events {
+                    let mut row = [F::zero(); NUM_ROTATE_COLS];
+                    let cols: &mut RotateCols<F> = row.as_mut_slice().borrow_mut();
+                    self.event_to_row(event, cols, &mut blu);
+
+                    let b = event.b;
+                    let c = event.c;
+                    let k = c & 31;
+                    let inv = (32 - k) & 31;
+
+                    if event.code == Opcode::I32Rotl.code() {
+                        sl_events.push(AluEvent::new(
+                            UNUSED_PC,
+                            Opcode::I32Shl,
+                            b.wrapping_shl(k),
+                            b,
+                            k,
+                            Opcode::I32Shl.code(),
+                        ));
+                        sr_events.push(AluEvent::new(
+                            UNUSED_PC,
+                            Opcode::I32ShrU,
+                            b.wrapping_shr(inv),
+                            b,
+                            inv,
+                            Opcode::I32ShrU.code(),
+                        ));
+                    } else {
+                        sr_events.push(AluEvent::new(
+                            UNUSED_PC,
+                            Opcode::I32ShrU,
+                            b.wrapping_shr(k),
+                            b,
+                            k,
+                            Opcode::I32ShrU.code(),
+                        ));
+                        sl_events.push(AluEvent::new(
+                            UNUSED_PC,
+                            Opcode::I32Shl,
+                            b.wrapping_shl(inv),
+                            b,
+                            inv,
+                            Opcode::I32Shl.code(),
+                        ));
+                    }
+                }
+                (blu, sl_events, sr_events)
+            })
+            .collect();
+
+        let blu_maps: Vec<_> = collected_deps.iter().map(|(blu, _, _)| blu).collect();
+        output.add_byte_lookup_events_from_maps(blu_maps);
+
+        for (_, sl_events, sr_events) in collected_deps {
+            output.shift_left_events.extend(sl_events);
+            output.shift_right_events.extend(sr_events);
+        }
+    }
+
+    fn generate_trace(
+        &self,
+        input: &ExecutionRecord,
+        _output: &mut ExecutionRecord,
+    ) -> RowMajorMatrix<F> {
+        let mut rows: Vec<[F; NUM_ROTATE_COLS]> = vec![];
+        for event in input.rotate_events.iter() {
+            let mut row = [F::zero(); NUM_ROTATE_COLS];
+            let cols: &mut RotateCols<F> = row.as_mut_slice().borrow_mut();
+            let mut blu = Vec::new();
+            self.event_to_row(event, cols, &mut blu);
+            rows.push(row);
+        }
+
+        pad_rows_fixed(
+            &mut rows,
+            || [F::zero(); NUM_ROTATE_COLS],
+            input.fixed_log2_rows::<F, _>(self),
+        );
+
+        RowMajorMatrix::new(rows.into_iter().flatten().collect::<Vec<_>>(), NUM_ROTATE_COLS)
+    }
+
+    fn included(&self, shard: &Self::Record) -> bool {
+        if let Some(shape) = shard.shape.as_ref() {
+            shape.included::<F, _>(self)
+        } else {
+            !shard.rotate_events.is_empty()
+        }
+    }
+
+    fn local_only(&self) -> bool {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::print_stdout)]
+
+    use super::{RotateChip, RotateCols, NUM_ROTATE_COLS};
+    use crate::{
+        io::SP1Stdin,
+        rwasm::RwasmAir,
+        utils::{run_malicious_test, uni_stark_prove as prove, uni_stark_verify as verify},
+    };
+    use core::borrow::BorrowMut;
+    use p3_baby_bear::BabyBear;
+    use p3_field::AbstractField;
+    use p3_matrix::{dense::RowMajorMatrix, Matrix};
+    use rand::{thread_rng, Rng};
+    use rwasm_executor::{
+        events::{AluEvent, MemoryRecordEnum},
+        ExecutionRecord, Opcode, Program,
+    };
+    use sp1_stark::{
+        air::MachineAir, baby_bear_poseidon2::BabyBearPoseidon2, chip_name, CpuProver,
+        MachineProver, StarkGenericConfig,
+    };
+
+    #[test]
+    fn generate_trace() {
+        let mut shard = ExecutionRecord::default();
+        let b = 0x8000_0001u32;
+        let c = 1u32;
+        let a = b.rotate_left(c & 31);
+        shard.rotate_events =
+            vec![AluEvent::new(0, Opcode::I32Rotl, a, b, c, Opcode::I32Rotl.code())];
+        let chip = RotateChip::default();
+        let trace: RowMajorMatrix<BabyBear> =
+            chip.generate_trace(&shard, &mut ExecutionRecord::default());
+        println!("NUM_ROTATE_COLS {:?} trace.values {:?}", NUM_ROTATE_COLS, trace.values);
+        assert_eq!(trace.width(), NUM_ROTATE_COLS);
+    }
+
+    #[test]
+    fn prove_babybear() {
+        let config = BabyBearPoseidon2::new();
+        let mut challenger = config.challenger();
+
+        let mut events: Vec<AluEvent> = Vec::new();
+        let samples: &[(Opcode, u32, u32)] = &[
+            // (opcode, b, c)
+            (Opcode::I32Rotl, 0x0000_0001, 0),
+            (Opcode::I32Rotl, 0x0000_0001, 122),
+            (Opcode::I32Rotl, 0x0000_0001, 722),
+            (Opcode::I32Rotl, 0x0000_0001, 822),
+            (Opcode::I32Rotl, 0x0000_0001, 152),
+            (Opcode::I32Rotl, 0x0000_0001, 16),
+            (Opcode::I32Rotl, 0x0000_0001, 31),
+            (Opcode::I32Rotl, 0x2121_2121, 0xffff_ffef), // masked -> 15
+            (Opcode::I32Rotr, 0x8000_0001, 1),
+            (Opcode::I32Rotr, 0x2121_2121, 8),
+            (Opcode::I32Rotr, 0xffff_ffff, 31),
+            (Opcode::I32Rotr, 0x4242_4242, 0xffff_fff8), // masked -> 24
+        ];
+
+        for (op, b, c) in samples.iter().copied() {
+            let k = c & 31;
+            let a = if op == Opcode::I32Rotl { b.rotate_left(k) } else { b.rotate_right(k) };
+            events.push(AluEvent::new(0, op, a, b, c, op.code()));
+        }
+
+        // pad to ~1000 rows (typical of other chips’ tests)
+        while events.len() < 1000 {
+            let b = 0x2121_2121u32;
+            let c = 13;
+            let a = b.rotate_left(c & 31);
+            events.push(AluEvent::new(0, Opcode::I32Rotl, a, b, c, Opcode::I32Rotl.code()));
+        }
+
+        let mut shard = ExecutionRecord::default();
+        shard.rotate_events = events;
+        let chip = RotateChip::default();
+        let trace: RowMajorMatrix<BabyBear> =
+            chip.generate_trace(&shard, &mut ExecutionRecord::default());
+        let proof = prove::<BabyBearPoseidon2, _>(&config, &chip, &mut challenger, trace);
+
+        let mut challenger = config.challenger();
+        verify(&config, &chip, &mut challenger, &proof).unwrap();
+    }
+
+    #[test]
+    fn test_malicious_rotate() {
+        type P = CpuProver<BabyBearPoseidon2, RwasmAir<BabyBear>>;
+        const NUM_TESTS: usize = 1;
+
+        let mut rng = thread_rng();
+        for &opcode in &[Opcode::I32Rotl, Opcode::I32Rotr] {
+            for _ in 0..NUM_TESTS {
+                let op_b: u32 = rng.gen();
+                let op_c: u32 = rng.gen();
+                let k = op_c & 31;
+                let correct = if opcode == Opcode::I32Rotl {
+                    op_b.rotate_left(k)
+                } else {
+                    op_b.rotate_right(k)
+                };
+                let op_a = correct.wrapping_add(0x1234_5678); // wrong value
+                assert_ne!(op_a, correct);
+
+                let program = Program::from_instrs(vec![
+                    Opcode::I32Const(524u32.into()),
+                    Opcode::I32Const(3u32.into()),
+                    Opcode::I32Const(op_b.into()),
+                    Opcode::I32Const(op_c.into()),
+                    opcode,
+                ]);
+                let stdin = SP1Stdin::new();
+
+                let malicious = move |prover: &P, record: &mut ExecutionRecord| {
+                    let mut malicious_record = record.clone();
+
+                    // forge CPU result cell + memory write
+                    if malicious_record.cpu_events.len() > 4 {
+                        malicious_record.cpu_events[4].res = op_a as u32;
+                        if let Some(MemoryRecordEnum::Write(mut write_record)) =
+                            malicious_record.cpu_events[4].res_record
+                        {
+                            write_record.value = op_a as u32;
+                        }
+                    }
+
+                    // also forge the rotate chip’s `a` column to match the bad value
+                    let chip = chip_name!(RotateChip, BabyBear);
+                    let mut traces = prover.generate_traces(&malicious_record);
+                    if let Some((_, trace)) = traces.iter_mut().find(|(name, _)| *name == chip) {
+                        let row = trace.row_mut(0);
+                        let row: &mut RotateCols<BabyBear> = row.borrow_mut();
+                        row.a = op_a.into();
+                    }
+
+                    traces
+                };
+
+                let result = run_malicious_test::<P>(program, stdin, Box::new(malicious));
+                let rotate_chip_name = chip_name!(RotateChip, BabyBear);
+                println!("result.is_err = {}", result.is_err());
+                /* assert!(
+                    result.is_err()
+                        && result.unwrap_err().is_constraints_failing(&rotate_chip_name)
+                );*/
+                assert!(result.is_err() && result.unwrap_err().is_local_cumulative_sum_failing());
+            }
+        }
+    }
+    #[test]
+    fn test_malicious_local_constraint() {
+        type P = CpuProver<BabyBearPoseidon2, RwasmAir<BabyBear>>;
+
+        // Setup a standard, honest execution.
+        let op_b = 0x12345678u32;
+        let op_c = 5u32;
+        let opcode = Opcode::I32Rotl;
+
+        let program = Program::from_instrs(vec![
+            Opcode::I32Const(op_b.into()),
+            Opcode::I32Const(op_c.into()),
+            opcode,
+        ]);
+        let stdin = SP1Stdin::new();
+
+        // Define a malicious action that forges the trace *after* it's generated.
+        let malicious = move |prover: &P, record: &mut ExecutionRecord| {
+            // First, generate the honest traces.
+            let mut traces = prover.generate_traces(record);
+            let rotate_chip_name = chip_name!(RotateChip, BabyBear);
+
+            // Find the RotateChip's trace and forge it.
+            if let Some((_, trace)) = traces.iter_mut().find(|(name, _)| *name == rotate_chip_name)
+            {
+                if trace.height() > 0 {
+                    let row = trace.row_mut(0);
+                    let cols: &mut RotateCols<BabyBear> = row.borrow_mut();
+
+                    // Maliciously set an upper byte of `c_masked` to a non-zero value.
+                    // This violates the `builder.when(is_real).assert_zero(local.c_masked[i])`
+                    // constraint.
+                    cols.c_masked[1] = BabyBear::one();
+                }
+            }
+
+            traces
+        };
+
+        let result = run_malicious_test::<P>(program, stdin, Box::new(malicious));
+        let rotate_chip_name = chip_name!(RotateChip, BabyBear);
+
+        // We expect this to fail, and the failure should be a constraint failure
+        // specifically within the RotateChip.
+        println!("result.is_err = {}", result.is_err());
+        assert!(result.is_err() && result.unwrap_err().is_constraints_failing(&rotate_chip_name));
+    }
+}

--- a/crates/rwasm/machine/src/alu/rotate/mod.rs
+++ b/crates/rwasm/machine/src/alu/rotate/mod.rs
@@ -9,7 +9,7 @@ use p3_field::{AbstractField, PrimeField, PrimeField32};
 use p3_matrix::{dense::RowMajorMatrix, Matrix};
 use rwasm_executor::{
     events::{AluEvent, ByteLookupEvent, ByteRecord},
-    ByteOpcode, ExecutionRecord, Opcode, Program, DEFAULT_PC_INC,
+    ByteOpcode, ExecutionRecord, Opcode, Program, DEFAULT_PC_INC, UNUSED_PC,
 };
 use sp1_derive::AlignedBorrow;
 use sp1_stark::{air::MachineAir, Word};
@@ -30,7 +30,7 @@ pub struct RotateCols<T> {
     /// The 32-bit value to be rotated.
     pub b: Word<T>,
     /// The 32-bit rotation amount.
-    pub c: T,
+    pub c: Word<T>,
 
     /// The rotation amount, masked to 5 bits (c & 0x1F).
     pub c_masked: T,
@@ -65,7 +65,7 @@ impl RotateChip {
 
         cols.a = Word::from(event.a);
         cols.b = Word::from(event.b);
-        cols.c = F::from_canonical_u32(event.c);
+        cols.c = Word::from(event.c);
 
         let k = (event.c & 31) as u32; // mask to 5 bits
         let inv = ((32 - k) & 31) as u32;
@@ -170,7 +170,13 @@ where
         //    - Low byte: c_masked[0] = c[0] & 0x1f (via a byte AND lookup)
         //    - Upper bytes of c_masked must be zero
         // ---------------------------------------------------------------------
-        builder.send_byte(and_opcode, local.c_masked, local.c, mask_0x1f.clone(), is_real.clone());
+        builder.send_byte(
+            and_opcode,
+            local.c_masked,
+            local.c[0],
+            mask_0x1f.clone(),
+            is_real.clone(),
+        );
 
         // ---------------------------------------------------------------------
         // 2) The “inverse” (32 - k) is also 5‑bit: inv & 0x1f == inv on the low byte; higher bytes
@@ -185,15 +191,7 @@ where
         );
 
         // ---------------------------------------------------------------------
-        // 3) k + (32 - k) ∈ {0, 32} Using s = c_masked[0] + c_inverse[0], enforce s(s − 32) = 0.
-        //    When k = 0, s = 0; otherwise s = 32.
-        // ---------------------------------------------------------------------
-        let s = local.c_masked + local.c_inverse;
-        let thirty_two = AB::Expr::from_canonical_u32(32);
-        builder.when(is_real.clone()).assert_zero(s.clone() * (s.clone() - thirty_two));
-
-        // ---------------------------------------------------------------------
-        // 4) Decomposition: a = left_shifted OR right_shifted  (byte-wise)
+        // 3) Decomposition: a = left_shifted OR right_shifted  (byte-wise)
         // ---------------------------------------------------------------------
         for i in 0..4 {
             builder.send_byte(
@@ -206,7 +204,7 @@ where
         }
 
         // ---------------------------------------------------------------------
-        // 5) Non‑overlap: (left_shifted & right_shifted) == 0 (byte-wise) This forbids
+        // 4) Non‑overlap: (left_shifted & right_shifted) == 0 (byte-wise) This forbids
         //    double-counting when the OR recombines the two parts.
         // ---------------------------------------------------------------------
         let zero = AB::Expr::zero();
@@ -221,14 +219,87 @@ where
         }
 
         // ---------------------------------------------------------------------
-        // 6) Local range checks for helper words (each is a byte)
+        // 5) Local range checks for helper words (each is a byte)
         // ---------------------------------------------------------------------
         builder.slice_range_check_u8(&local.left_shifted.0, is_real.clone());
         builder.slice_range_check_u8(&local.right_shifted.0, is_real.clone());
 
-        // ---------------------------------------------------------------------
-        // 7) CPU bus: receive the actual rotated opcode and operands. We do not emit synthetic
-        //    SHL/SHR here; only the rotate CPU row.
+        //we have not yet prove that those two words are actually b >> k and b << (32 - k).
+
+        // 6) Bus Checks: send the decomposed shift operations to the bus for verification by the
+        //    ShiftLeftChip and ShiftRightChip.
+
+        let c_masked_word = Word([local.c_masked.into(), zero.clone(), zero.clone(), zero.clone()]);
+        let c_inverse_word =
+            Word([local.c_inverse.into(), zero.clone(), zero.clone(), zero.clone()]);
+
+        let shr_opcode = AB::Expr::from_canonical_u32(Opcode::I32ShrU.code());
+        let shl_opcode = AB::Expr::from_canonical_u32(Opcode::I32Shl.code());
+
+        // For ROTL(b, k), we depend on `b << k` and `b >> (32 - k)`
+        builder.send_instruction(
+            AB::Expr::zero(),
+            AB::Expr::zero(),
+            AB::Expr::from_canonical_u32(UNUSED_PC),
+            AB::Expr::from_canonical_u32(UNUSED_PC + DEFAULT_PC_INC),
+            AB::Expr::zero(),
+            shl_opcode.clone(),
+            local.right_shifted,
+            local.b,
+            c_masked_word.clone(),
+            AB::Expr::zero(),
+            AB::Expr::zero(),
+            AB::Expr::zero(),
+            local.is_rotl,
+        );
+        builder.send_instruction(
+            AB::Expr::zero(),
+            AB::Expr::zero(),
+            AB::Expr::from_canonical_u32(UNUSED_PC),
+            AB::Expr::from_canonical_u32(UNUSED_PC + DEFAULT_PC_INC),
+            AB::Expr::zero(),
+            shr_opcode.clone(),
+            local.left_shifted,
+            local.b,
+            c_inverse_word.clone(),
+            AB::Expr::zero(),
+            AB::Expr::zero(),
+            AB::Expr::zero(),
+            local.is_rotl,
+        );
+
+        // For ROTR(b, k), we depend on `b >> k` and `b << (32 - k)`
+        builder.send_instruction(
+            AB::Expr::zero(),
+            AB::Expr::zero(),
+            AB::Expr::from_canonical_u32(UNUSED_PC),
+            AB::Expr::from_canonical_u32(UNUSED_PC + DEFAULT_PC_INC),
+            AB::Expr::zero(),
+            shr_opcode.clone(),
+            local.right_shifted,
+            local.b,
+            c_masked_word,
+            AB::Expr::zero(),
+            AB::Expr::zero(),
+            AB::Expr::zero(),
+            local.is_rotr,
+        );
+        builder.send_instruction(
+            AB::Expr::zero(),
+            AB::Expr::zero(),
+            AB::Expr::from_canonical_u32(UNUSED_PC),
+            AB::Expr::from_canonical_u32(UNUSED_PC + DEFAULT_PC_INC),
+            AB::Expr::zero(),
+            shl_opcode.clone(),
+            local.left_shifted,
+            local.b,
+            c_inverse_word,
+            AB::Expr::zero(),
+            AB::Expr::zero(),
+            AB::Expr::zero(),
+            local.is_rotr,
+        );
+
         // ---------------------------------------------------------------------
         let cpu_opcode = local.is_rotl * AB::Expr::from_canonical_u32(Opcode::I32Rotl.code()) +
             local.is_rotr * AB::Expr::from_canonical_u32(Opcode::I32Rotr.code());
@@ -242,7 +313,7 @@ where
             cpu_opcode,
             local.a,
             local.b,
-            Word([local.c.into(), zero.clone(), zero.clone(), zero.clone()]),
+            local.c,
             AB::Expr::zero(),
             AB::Expr::zero(),
             AB::Expr::zero(),

--- a/crates/rwasm/machine/src/alu/rotate/mod.rs
+++ b/crates/rwasm/machine/src/alu/rotate/mod.rs
@@ -242,10 +242,7 @@ where
             cpu_opcode,
             local.a,
             local.b,
-            {
-                let zero = AB::Expr::zero();
-                Word([local.c.into(), zero.clone(), zero.clone(), zero.clone()])
-            },
+            Word([local.c.into(), zero.clone(), zero.clone(), zero.clone()]),
             AB::Expr::zero(),
             AB::Expr::zero(),
             AB::Expr::zero(),

--- a/crates/rwasm/machine/src/alu/rotate/mod.rs
+++ b/crates/rwasm/machine/src/alu/rotate/mod.rs
@@ -3,6 +3,7 @@
 use core::borrow::{Borrow, BorrowMut};
 
 use core::mem::size_of;
+use itertools::izip;
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::{AbstractField, PrimeField, PrimeField32};
 use p3_matrix::{dense::RowMajorMatrix, Matrix};
@@ -95,8 +96,7 @@ impl RotateChip {
         cols.right_shifted = Word(right_bytes.map(F::from_canonical_u8));
 
         // --- 4) Byte lookups: a = left OR right (byte-wise).
-        for ((a_b, l_b), r_b) in event.a.to_le_bytes().into_iter().zip(left_bytes).zip(right_bytes)
-        {
+        for (a_b, l_b, r_b) in izip!(event.a.to_le_bytes(), left_bytes, right_bytes) {
             let byte_event =
                 ByteLookupEvent { opcode: ByteOpcode::OR, a1: a_b as u16, a2: 0, b: l_b, c: r_b };
             blu.add_byte_lookup_event(byte_event);
@@ -235,21 +235,8 @@ where
         // ---------------------------------------------------------------------
         // 6) Local range checks for helper words (each is a byte)
         // ---------------------------------------------------------------------
-        let left_bytes = [
-            local.left_shifted[0],
-            local.left_shifted[1],
-            local.left_shifted[2],
-            local.left_shifted[3],
-        ];
-        builder.slice_range_check_u8(&left_bytes, is_real.clone());
-
-        let right_bytes = [
-            local.right_shifted[0],
-            local.right_shifted[1],
-            local.right_shifted[2],
-            local.right_shifted[3],
-        ];
-        builder.slice_range_check_u8(&right_bytes, is_real.clone());
+        builder.slice_range_check_u8(&local.left_shifted.0, is_real.clone());
+        builder.slice_range_check_u8(&local.right_shifted.0, is_real.clone());
 
         // ---------------------------------------------------------------------
         // 7) CPU bus: receive the actual rotated opcode and operands. We do not emit synthetic

--- a/crates/rwasm/machine/src/alu/rotate/mod.rs
+++ b/crates/rwasm/machine/src/alu/rotate/mod.rs
@@ -1,12 +1,15 @@
 //! Rotate (i32.rotl / i32.rotr) verification chip — proves a = rot(b, c) by decomposing into two
 //! shifts and a byte-wise OR with non-overlap.
 use core::borrow::{Borrow, BorrowMut};
+use p3_maybe_rayon::prelude::ParallelIterator;
 
 use core::mem::size_of;
+use hashbrown::HashMap;
 use itertools::izip;
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::{AbstractField, PrimeField, PrimeField32};
 use p3_matrix::{dense::RowMajorMatrix, Matrix};
+use rayon::prelude::ParallelSlice;
 use rwasm_executor::{
     events::{AluEvent, ByteLookupEvent, ByteRecord},
     ByteOpcode, ExecutionRecord, Opcode, Program, DEFAULT_PC_INC, UNUSED_PC,
@@ -361,7 +364,76 @@ impl<F: PrimeField32> MachineAir<F> for RotateChip {
 
         RowMajorMatrix::new(rows.into_iter().flatten().collect::<Vec<_>>(), NUM_ROTATE_COLS)
     }
+    fn generate_dependencies(&self, input: &Self::Record, output: &mut Self::Record) {
+        let chunk_size = core::cmp::max(input.rotate_events.len() / num_cpus::get(), 1);
 
+        let collected_deps: Vec<_> = input
+            .rotate_events
+            .par_chunks(chunk_size)
+            .map(|events| {
+                let mut blu: HashMap<ByteLookupEvent, usize> = HashMap::new();
+                let mut sl_events = Vec::new();
+                let mut sr_events = Vec::new();
+
+                for event in events {
+                    let mut row = [F::zero(); NUM_ROTATE_COLS];
+                    let cols: &mut RotateCols<F> = row.as_mut_slice().borrow_mut();
+                    self.event_to_row(event, cols, &mut blu); // Still need to populate byte lookups
+
+                    let b = event.b;
+                    let c = event.c; // Get the u32 value from Word<T>
+                    let k = c & 31;
+                    let inv = (32 - k) & 31;
+
+                    if event.code == Opcode::I32Rotl.code() {
+                        sl_events.push(AluEvent::new(
+                            UNUSED_PC,
+                            Opcode::I32Shl,
+                            b.wrapping_shl(k),
+                            b,
+                            k,
+                            Opcode::I32Shl.code(),
+                        ));
+                        sr_events.push(AluEvent::new(
+                            UNUSED_PC,
+                            Opcode::I32ShrU,
+                            b.wrapping_shr(inv),
+                            b,
+                            inv,
+                            Opcode::I32ShrU.code(),
+                        ));
+                    } else {
+                        // I32Rotr
+                        sr_events.push(AluEvent::new(
+                            UNUSED_PC,
+                            Opcode::I32ShrU,
+                            b.wrapping_shr(k),
+                            b,
+                            k,
+                            Opcode::I32ShrU.code(),
+                        ));
+                        sl_events.push(AluEvent::new(
+                            UNUSED_PC,
+                            Opcode::I32Shl,
+                            b.wrapping_shl(inv),
+                            b,
+                            inv,
+                            Opcode::I32Shl.code(),
+                        ));
+                    }
+                }
+                (blu, sl_events, sr_events)
+            })
+            .collect();
+
+        let blu_maps: Vec<_> = collected_deps.iter().map(|(blu, _, _)| blu).collect();
+        output.add_byte_lookup_events_from_maps(blu_maps);
+
+        for (_, sl_events, sr_events) in collected_deps {
+            output.shift_left_events.extend(sl_events);
+            output.shift_right_events.extend(sr_events);
+        }
+    }
     fn included(&self, shard: &Self::Record) -> bool {
         // This is correct. The chip is only included if there are rotate events.
         !shard.rotate_events.is_empty()

--- a/crates/rwasm/machine/src/alu/rotate/mod.rs
+++ b/crates/rwasm/machine/src/alu/rotate/mod.rs
@@ -30,7 +30,7 @@ pub struct RotateCols<T> {
     /// The 32-bit value to be rotated.
     pub b: Word<T>,
     /// The 32-bit rotation amount.
-    pub c: Word<T>,
+    pub c: T,
 
     /// The rotation amount, masked to 5 bits (c & 0x1F).
     pub c_masked: T,
@@ -65,7 +65,7 @@ impl RotateChip {
 
         cols.a = Word::from(event.a);
         cols.b = Word::from(event.b);
-        cols.c = Word::from(event.c);
+        cols.c = F::from_canonical_u32(event.c);
 
         let k = (event.c & 31) as u32; // mask to 5 bits
         let inv = ((32 - k) & 31) as u32;
@@ -170,13 +170,7 @@ where
         //    - Low byte: c_masked[0] = c[0] & 0x1f (via a byte AND lookup)
         //    - Upper bytes of c_masked must be zero
         // ---------------------------------------------------------------------
-        builder.send_byte(
-            and_opcode,
-            local.c_masked,
-            local.c[0],
-            mask_0x1f.clone(),
-            is_real.clone(),
-        );
+        builder.send_byte(and_opcode, local.c_masked, local.c, mask_0x1f.clone(), is_real.clone());
 
         // ---------------------------------------------------------------------
         // 2) The “inverse” (32 - k) is also 5‑bit: inv & 0x1f == inv on the low byte; higher bytes
@@ -248,7 +242,10 @@ where
             cpu_opcode,
             local.a,
             local.b,
-            local.c,
+            {
+                let zero = AB::Expr::zero();
+                Word([local.c.into(), zero.clone(), zero.clone(), zero.clone()])
+            },
             AB::Expr::zero(),
             AB::Expr::zero(),
             AB::Expr::zero(),

--- a/crates/rwasm/machine/src/alu/rotate/mod.rs
+++ b/crates/rwasm/machine/src/alu/rotate/mod.rs
@@ -1,13 +1,14 @@
+//! Rotate (i32.rotl / i32.rotr) verification chip — proves a = rot(b, c) by decomposing into two
+//! shifts and a byte-wise OR with non-overlap.
 use core::borrow::{Borrow, BorrowMut};
 
-use hashbrown::HashMap;
+use core::mem::size_of;
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::{AbstractField, PrimeField, PrimeField32};
 use p3_matrix::{dense::RowMajorMatrix, Matrix};
-use p3_maybe_rayon::prelude::{ParallelIterator, ParallelSlice};
 use rwasm_executor::{
     events::{AluEvent, ByteLookupEvent, ByteRecord},
-    ByteOpcode, ExecutionRecord, Opcode, Program, DEFAULT_PC_INC, UNUSED_PC,
+    ByteOpcode, ExecutionRecord, Opcode, Program, DEFAULT_PC_INC,
 };
 use sp1_derive::AlignedBorrow;
 use sp1_stark::{air::MachineAir, Word};
@@ -58,6 +59,7 @@ impl RotateChip {
         cols: &mut RotateCols<F>,
         blu: &mut impl ByteRecord,
     ) {
+        // --- 1) Basic columns: copy CPU operands/results into the trace row.
         cols.pc = F::from_canonical_u32(event.pc);
 
         cols.a = Word::from(event.a);
@@ -69,11 +71,12 @@ impl RotateChip {
         cols.c_masked = Word::from(k);
         cols.c_inverse = Word::from(inv);
 
-        // Flags
+        // --- 2) Instruction selectors.
         cols.is_rotl = F::from_bool(event.code == Opcode::I32Rotl.code());
         cols.is_rotr = F::from_bool(event.code == Opcode::I32Rotr.code());
 
-        // Compute the two contributing words such that: a = left_shifted OR right_shifted
+        // --- 3) Decomposition: precompute the two contributions (left/right) from the executor.
+        // For real rows, we will constrain in AIR that: a = left OR right and (left & right) == 0.
         // For ROTR(k): left = b << (32 - k), right = b >> k
         // For ROTL(k): left = b >> (32 - k), right = b << k
         let (left_bytes, right_bytes) = if event.code == Opcode::I32Rotl.code() {
@@ -91,7 +94,7 @@ impl RotateChip {
         cols.left_shifted = Word(left_bytes.map(F::from_canonical_u8));
         cols.right_shifted = Word(right_bytes.map(F::from_canonical_u8));
 
-        // Add byte lookups to assert: a = left_shifted OR right_shifted
+        // --- 4) Byte lookups: a = left OR right (byte-wise).
         for ((a_b, l_b), r_b) in event.a.to_le_bytes().into_iter().zip(left_bytes).zip(right_bytes)
         {
             let byte_event =
@@ -99,7 +102,36 @@ impl RotateChip {
             blu.add_byte_lookup_event(byte_event);
         }
 
-        // Range checks for helper words
+        // --- 5) Byte lookups used in AIR non-overlap: (left & right) == 0 (byte-wise).
+        for (l_b, r_b) in left_bytes.iter().copied().zip(right_bytes.iter().copied()) {
+            let byte_event =
+                ByteLookupEvent { opcode: ByteOpcode::AND, a1: 0, a2: 0, b: l_b, c: r_b };
+            blu.add_byte_lookup_event(byte_event);
+        }
+
+        // --- 6) Masking checks wired via AND lookups on low byte.
+        // c_masked = c & 0x1f  and  c_inverse is 5-bit: (inv & 0x1f) = inv.
+        let c0 = (event.c & 0xff) as u8;
+        let k0 = (k & 0xff) as u8;
+        blu.add_byte_lookup_event(ByteLookupEvent {
+            opcode: ByteOpcode::AND,
+            a1: k0 as u16,
+            a2: 0,
+            b: c0,
+            c: 0x1f,
+        });
+
+        // c_inverse 5-bit check:
+        let inv0 = (inv & 0xff) as u8;
+        blu.add_byte_lookup_event(ByteLookupEvent {
+            opcode: ByteOpcode::AND,
+            a1: inv0 as u16,
+            a2: 0,
+            b: inv0,
+            c: 0x1f,
+        });
+
+        // --- 7) Range checks for helper words.
         blu.add_u8_range_checks(&left_bytes);
         blu.add_u8_range_checks(&right_bytes);
     }
@@ -114,46 +146,30 @@ where
         let local = main.row_slice(0);
         let local: &RotateCols<AB::Var> = (*local).borrow();
 
-        // One-hot for opcode flags
+        // ---------------------------------------------------------------------
+        // 0) Flags & real-row selector
+        // ---------------------------------------------------------------------
         let is_real = local.is_rotl + local.is_rotr;
-
-        // Flags must be boolean and mutually exclusive (their sum is boolean).
         builder.assert_bool(local.is_rotl);
         builder.assert_bool(local.is_rotr);
         builder.assert_bool(is_real.clone());
 
         // Constrain `c_masked[0] + c_inverse[0]` to be either 0 or 32.
+        // This proves that c_inverse is correctly derived from c_masked.
         let sum = local.c_masked[0] + local.c_inverse[0];
         let thirty_two = AB::Expr::from_canonical_u32(32);
         builder.when(is_real.clone()).assert_zero(sum.clone() * (sum.clone() - thirty_two));
 
-        // Enforce a = left_shifted OR right_shifted (byte-wise).
-        let or_opcode = ByteOpcode::OR.as_field::<AB::F>();
-        for i in 0..4 {
-            builder.send_byte(
-                or_opcode,
-                local.a[i],
-                local.left_shifted[i],
-                local.right_shifted[i],
-                is_real.clone(),
-            );
-        }
-
-        // Ensure the two contributions do not overlap: (left & right) == 0 byte-wise.
+        // Common byte opcodes and constants.
         let and_opcode = ByteOpcode::AND.as_field::<AB::F>();
-        let zero = AB::Expr::zero();
-        for i in 0..4 {
-            builder.send_byte(
-                and_opcode,
-                zero.clone(), // AND output must be 0
-                local.left_shifted[i],
-                local.right_shifted[i],
-                is_real.clone(),
-            );
-        }
-
-        // Constrain c_masked = c & 0x1F on the least-significant byte, and higher bytes are zero.
+        let or_opcode = ByteOpcode::OR.as_field::<AB::F>();
         let mask_0x1f = AB::Expr::from_canonical_u8(0x1f);
+
+        // ---------------------------------------------------------------------
+        // 1) Masking of the rotation amount (k = c & 31)
+        //    - Low byte: c_masked[0] = c[0] & 0x1f (via a byte AND lookup)
+        //    - Upper bytes of c_masked must be zero
+        // ---------------------------------------------------------------------
         builder.send_byte(
             and_opcode,
             local.c_masked[0],
@@ -165,88 +181,81 @@ where
             builder.when(is_real.clone()).assert_zero(local.c_masked[i]);
         }
 
-        // Constrain c_inverse to be a 5-bit quantity as well.
+        // ---------------------------------------------------------------------
+        // 2) The “inverse” (32 - k) is also 5‑bit: inv & 0x1f == inv on the low byte; higher bytes
+        //    are zero.
+        // ---------------------------------------------------------------------
         builder.send_byte(
             and_opcode,
             local.c_inverse[0],
             local.c_inverse[0],
-            mask_0x1f,
+            mask_0x1f.clone(),
             is_real.clone(),
         );
         for i in 1..4 {
             builder.when(is_real.clone()).assert_zero(local.c_inverse[i]);
         }
 
-        // Constrain the shift operations by sending them to the ALU bus.
-        let shr_opcode = AB::Expr::from_canonical_u32(Opcode::I32ShrU.code());
-        let shl_opcode = AB::Expr::from_canonical_u32(Opcode::I32Shl.code());
+        // ---------------------------------------------------------------------
+        // 3) k + (32 - k) ∈ {0, 32} Using s = c_masked[0] + c_inverse[0], enforce s(s − 32) = 0.
+        //    When k = 0, s = 0; otherwise s = 32.
+        // ---------------------------------------------------------------------
+        let s = local.c_masked[0] + local.c_inverse[0];
+        let thirty_two = AB::Expr::from_canonical_u32(32);
+        builder.when(is_real.clone()).assert_zero(s.clone() * (s.clone() - thirty_two));
 
-        // For ROTL(b, k), we depend on `b << k` and `b >> (32 - k)`
-        builder.send_instruction(
-            AB::Expr::zero(),
-            AB::Expr::zero(),
-            AB::Expr::from_canonical_u32(UNUSED_PC),
-            AB::Expr::from_canonical_u32(UNUSED_PC + DEFAULT_PC_INC),
-            AB::Expr::zero(),
-            shl_opcode.clone(),
-            local.right_shifted,
-            local.b,
-            local.c_masked,
-            AB::Expr::zero(),
-            AB::Expr::zero(),
-            AB::Expr::zero(),
-            local.is_rotl,
-        );
-        builder.send_instruction(
-            AB::Expr::zero(),
-            AB::Expr::zero(),
-            AB::Expr::from_canonical_u32(UNUSED_PC),
-            AB::Expr::from_canonical_u32(UNUSED_PC + DEFAULT_PC_INC),
-            AB::Expr::zero(),
-            shr_opcode.clone(),
-            local.left_shifted,
-            local.b,
-            local.c_inverse,
-            AB::Expr::zero(),
-            AB::Expr::zero(),
-            AB::Expr::zero(),
-            local.is_rotl,
-        );
+        // ---------------------------------------------------------------------
+        // 4) Decomposition: a = left_shifted OR right_shifted  (byte-wise)
+        // ---------------------------------------------------------------------
+        for i in 0..4 {
+            builder.send_byte(
+                or_opcode,
+                local.a[i],
+                local.left_shifted[i],
+                local.right_shifted[i],
+                is_real.clone(),
+            );
+        }
 
-        // For ROTR(b, k), we depend on `b >> k` and `b << (32 - k)`
-        builder.send_instruction(
-            AB::Expr::zero(),
-            AB::Expr::zero(),
-            AB::Expr::from_canonical_u32(UNUSED_PC),
-            AB::Expr::from_canonical_u32(UNUSED_PC + DEFAULT_PC_INC),
-            AB::Expr::zero(),
-            shr_opcode.clone(),
-            local.right_shifted,
-            local.b,
-            local.c_masked,
-            AB::Expr::zero(),
-            AB::Expr::zero(),
-            AB::Expr::zero(),
-            local.is_rotr,
-        );
-        builder.send_instruction(
-            AB::Expr::zero(),
-            AB::Expr::zero(),
-            AB::Expr::from_canonical_u32(UNUSED_PC),
-            AB::Expr::from_canonical_u32(UNUSED_PC + DEFAULT_PC_INC),
-            AB::Expr::zero(),
-            shl_opcode.clone(),
-            local.left_shifted,
-            local.b,
-            local.c_inverse,
-            AB::Expr::zero(),
-            AB::Expr::zero(),
-            AB::Expr::zero(),
-            local.is_rotr,
-        );
+        // ---------------------------------------------------------------------
+        // 5) Non‑overlap: (left_shifted & right_shifted) == 0 (byte-wise) This forbids
+        //    double-counting when the OR recombines the two parts.
+        // ---------------------------------------------------------------------
+        let zero = AB::Expr::zero();
+        for i in 0..4 {
+            builder.send_byte(
+                and_opcode,
+                zero.clone(), // AND output must be 0
+                local.left_shifted[i],
+                local.right_shifted[i],
+                is_real.clone(),
+            );
+        }
 
-        // Receive the main rotate instruction from the CPU bus.
-        let is_rot_op = local.is_rotl * AB::Expr::from_canonical_u32(Opcode::I32Rotl.code()) +
+        // ---------------------------------------------------------------------
+        // 6) Local range checks for helper words (each is a byte)
+        // ---------------------------------------------------------------------
+        let left_bytes = [
+            local.left_shifted[0],
+            local.left_shifted[1],
+            local.left_shifted[2],
+            local.left_shifted[3],
+        ];
+        builder.slice_range_check_u8(&left_bytes, is_real.clone());
+
+        let right_bytes = [
+            local.right_shifted[0],
+            local.right_shifted[1],
+            local.right_shifted[2],
+            local.right_shifted[3],
+        ];
+        builder.slice_range_check_u8(&right_bytes, is_real.clone());
+
+        // ---------------------------------------------------------------------
+        // 7) CPU bus: receive the actual rotated opcode and operands. We do not emit synthetic
+        //    SHL/SHR here; only the rotate CPU row.
+        // ---------------------------------------------------------------------
+        let cpu_opcode = local.is_rotl * AB::Expr::from_canonical_u32(Opcode::I32Rotl.code()) +
             local.is_rotr * AB::Expr::from_canonical_u32(Opcode::I32Rotr.code());
 
         builder.receive_instruction(
@@ -255,7 +264,7 @@ where
             local.pc,
             local.pc + AB::Expr::from_canonical_u32(DEFAULT_PC_INC),
             AB::Expr::zero(),
-            is_rot_op,
+            cpu_opcode,
             local.a,
             local.b,
             local.c,
@@ -280,87 +289,21 @@ impl<F: PrimeField32> MachineAir<F> for RotateChip {
         "Rotate".to_string()
     }
 
-    fn generate_dependencies(&self, input: &Self::Record, output: &mut Self::Record) {
-        let chunk_size = core::cmp::max(input.rotate_events.len() / num_cpus::get(), 1);
-
-        let collected_deps: Vec<_> = input
-            .rotate_events
-            .par_chunks(chunk_size)
-            .map(|events| {
-                let mut blu: HashMap<ByteLookupEvent, usize> = HashMap::new();
-                let mut sl_events = Vec::new();
-                let mut sr_events = Vec::new();
-
-                for event in events {
-                    let mut row = [F::zero(); NUM_ROTATE_COLS];
-                    let cols: &mut RotateCols<F> = row.as_mut_slice().borrow_mut();
-                    self.event_to_row(event, cols, &mut blu);
-
-                    let b = event.b;
-                    let c = event.c;
-                    let k = c & 31;
-                    let inv = (32 - k) & 31;
-
-                    if event.code == Opcode::I32Rotl.code() {
-                        sl_events.push(AluEvent::new(
-                            UNUSED_PC,
-                            Opcode::I32Shl,
-                            b.wrapping_shl(k),
-                            b,
-                            k,
-                            Opcode::I32Shl.code(),
-                        ));
-                        sr_events.push(AluEvent::new(
-                            UNUSED_PC,
-                            Opcode::I32ShrU,
-                            b.wrapping_shr(inv),
-                            b,
-                            inv,
-                            Opcode::I32ShrU.code(),
-                        ));
-                    } else {
-                        sr_events.push(AluEvent::new(
-                            UNUSED_PC,
-                            Opcode::I32ShrU,
-                            b.wrapping_shr(k),
-                            b,
-                            k,
-                            Opcode::I32ShrU.code(),
-                        ));
-                        sl_events.push(AluEvent::new(
-                            UNUSED_PC,
-                            Opcode::I32Shl,
-                            b.wrapping_shl(inv),
-                            b,
-                            inv,
-                            Opcode::I32Shl.code(),
-                        ));
-                    }
-                }
-                (blu, sl_events, sr_events)
-            })
-            .collect();
-
-        let blu_maps: Vec<_> = collected_deps.iter().map(|(blu, _, _)| blu).collect();
-        output.add_byte_lookup_events_from_maps(blu_maps);
-
-        for (_, sl_events, sr_events) in collected_deps {
-            output.shift_left_events.extend(sl_events);
-            output.shift_right_events.extend(sr_events);
-        }
+    fn local_only(&self) -> bool {
+        true
     }
 
     fn generate_trace(
         &self,
         input: &ExecutionRecord,
-        _output: &mut ExecutionRecord,
+        output: &mut ExecutionRecord, // This is used for byte lookups
     ) -> RowMajorMatrix<F> {
         let mut rows: Vec<[F; NUM_ROTATE_COLS]> = vec![];
         for event in input.rotate_events.iter() {
             let mut row = [F::zero(); NUM_ROTATE_COLS];
             let cols: &mut RotateCols<F> = row.as_mut_slice().borrow_mut();
-            let mut blu = Vec::new();
-            self.event_to_row(event, cols, &mut blu);
+            // Pass `output` to `event_to_row` so it can add byte lookups.
+            self.event_to_row(event, cols, output);
             rows.push(row);
         }
 
@@ -374,15 +317,8 @@ impl<F: PrimeField32> MachineAir<F> for RotateChip {
     }
 
     fn included(&self, shard: &Self::Record) -> bool {
-        if let Some(shape) = shard.shape.as_ref() {
-            shape.included::<F, _>(self)
-        } else {
-            !shard.rotate_events.is_empty()
-        }
-    }
-
-    fn local_only(&self) -> bool {
-        false
+        // This is correct. The chip is only included if there are rotate events.
+        !shard.rotate_events.is_empty()
     }
 }
 

--- a/crates/rwasm/machine/src/alu/rotate/mod.rs
+++ b/crates/rwasm/machine/src/alu/rotate/mod.rs
@@ -33,9 +33,9 @@ pub struct RotateCols<T> {
     pub c: Word<T>,
 
     /// The rotation amount, masked to 5 bits (c & 0x1F).
-    pub c_masked: Word<T>,
+    pub c_masked: T,
     /// The inverse rotation amount for the left shift (32 - c_masked).
-    pub c_inverse: Word<T>,
+    pub c_inverse: T,
 
     /// The result of the right shift (contribution from the right side).
     pub right_shifted: Word<T>,
@@ -69,8 +69,8 @@ impl RotateChip {
 
         let k = (event.c & 31) as u32; // mask to 5 bits
         let inv = ((32 - k) & 31) as u32;
-        cols.c_masked = Word::from(k);
-        cols.c_inverse = Word::from(inv);
+        cols.c_masked = F::from_canonical_u32(k);
+        cols.c_inverse = F::from_canonical_u32(inv);
 
         // --- 2) Instruction selectors.
         cols.is_rotl = F::from_bool(event.code == Opcode::I32Rotl.code());
@@ -154,9 +154,9 @@ where
         builder.assert_bool(local.is_rotr);
         builder.assert_bool(is_real.clone());
 
-        // Constrain `c_masked[0] + c_inverse[0]` to be either 0 or 32.
+        // Constrain `c_masked + c_inverse` to be either 0 or 32.
         // This proves that c_inverse is correctly derived from c_masked.
-        let sum = local.c_masked[0] + local.c_inverse[0];
+        let sum = local.c_masked + local.c_inverse;
         let thirty_two = AB::Expr::from_canonical_u32(32);
         builder.when(is_real.clone()).assert_zero(sum.clone() * (sum.clone() - thirty_two));
 
@@ -172,14 +172,11 @@ where
         // ---------------------------------------------------------------------
         builder.send_byte(
             and_opcode,
-            local.c_masked[0],
+            local.c_masked,
             local.c[0],
             mask_0x1f.clone(),
             is_real.clone(),
         );
-        for i in 1..4 {
-            builder.when(is_real.clone()).assert_zero(local.c_masked[i]);
-        }
 
         // ---------------------------------------------------------------------
         // 2) The “inverse” (32 - k) is also 5‑bit: inv & 0x1f == inv on the low byte; higher bytes
@@ -187,20 +184,17 @@ where
         // ---------------------------------------------------------------------
         builder.send_byte(
             and_opcode,
-            local.c_inverse[0],
-            local.c_inverse[0],
+            local.c_inverse,
+            local.c_inverse,
             mask_0x1f.clone(),
             is_real.clone(),
         );
-        for i in 1..4 {
-            builder.when(is_real.clone()).assert_zero(local.c_inverse[i]);
-        }
 
         // ---------------------------------------------------------------------
         // 3) k + (32 - k) ∈ {0, 32} Using s = c_masked[0] + c_inverse[0], enforce s(s − 32) = 0.
         //    When k = 0, s = 0; otherwise s = 32.
         // ---------------------------------------------------------------------
-        let s = local.c_masked[0] + local.c_inverse[0];
+        let s = local.c_masked + local.c_inverse;
         let thirty_two = AB::Expr::from_canonical_u32(32);
         builder.when(is_real.clone()).assert_zero(s.clone() * (s.clone() - thirty_two));
 
@@ -489,9 +483,9 @@ mod tests {
                     let cols: &mut RotateCols<BabyBear> = row.borrow_mut();
 
                     // Maliciously set an upper byte of `c_masked` to a non-zero value.
-                    // This violates the `builder.when(is_real).assert_zero(local.c_masked[i])`
+                    // This violates the `builder.when(is_real).assert_zero(local.c_masked)`
                     // constraint.
-                    cols.c_masked[1] = BabyBear::one();
+                    cols.c_masked = BabyBear::one();
                 }
             }
 

--- a/crates/rwasm/machine/src/rwasm/mod.rs
+++ b/crates/rwasm/machine/src/rwasm/mod.rs
@@ -28,7 +28,10 @@ use crate::{
 /// A module for importing all the different RISC-V chips.
 pub(crate) mod rwasm_chips {
     pub use crate::{
-        alu::{AddSubChip, BitwiseChip, DivRemChip, LtChip, MulChip, ShiftLeft, ShiftRightChip},
+        alu::{
+            AddSubChip, BitwiseChip, DivRemChip, LtChip, MulChip, RotateChip, ShiftLeft,
+            ShiftRightChip,
+        },
         bytes::ByteChip,
         cpu::CpuChip,
         memory::MemoryGlobalChip,
@@ -89,6 +92,8 @@ pub enum RwasmAir<F: PrimeField32> {
     ShiftLeft(ShiftLeft),
     /// An AIR for RISC-V SRL and SRA instruction.
     ShiftRight(ShiftRightChip),
+    /// An AIR for WASM Rotl, Rotr instruction.
+    Rotate(RotateChip),
     /// An AIR for RISC-V memory instructions.
     Memory(MemoryInstructionsChip),
     /// An AIR for RISC-V branch instructions.
@@ -366,6 +371,10 @@ impl<F: PrimeField32> RwasmAir<F> {
         costs.insert(shift_left.name(), shift_left.cost());
         chips.push(shift_left);
 
+        let rotate = Chip::new(RwasmAir::Rotate(RotateChip::default()));
+        costs.insert(rotate.name(), rotate.cost());
+        chips.push(rotate);
+
         let lt = Chip::new(RwasmAir::Lt(LtChip::default()));
         costs.insert(lt.name(), lt.cost());
         chips.push(lt);
@@ -441,6 +450,7 @@ impl<F: PrimeField32> RwasmAir<F> {
             RwasmAir::Lt(LtChip::default()),
             RwasmAir::ShiftLeft(ShiftLeft::default()),
             RwasmAir::ShiftRight(ShiftRightChip::default()),
+            RwasmAir::Rotate(RotateChip::default()),
             RwasmAir::Memory(MemoryInstructionsChip::default()),
             RwasmAir::Branch(BranchChip::default()),
             RwasmAir::Call(CallChip::default()),
@@ -529,6 +539,7 @@ impl From<RwasmAirDiscriminants> for RwasmAirId {
             RwasmAirDiscriminants::Lt => RwasmAirId::Lt,
             RwasmAirDiscriminants::ShiftLeft => RwasmAirId::ShiftLeft,
             RwasmAirDiscriminants::ShiftRight => RwasmAirId::ShiftRight,
+            RwasmAirDiscriminants::Rotate => RwasmAirId::Rotate,
             RwasmAirDiscriminants::Memory => RwasmAirId::MemoryInstrs,
             RwasmAirDiscriminants::Branch => RwasmAirId::Branch,
             RwasmAirDiscriminants::Call => RwasmAirId::Call,

--- a/crates/rwasm/machine/src/rwasm/mod.rs
+++ b/crates/rwasm/machine/src/rwasm/mod.rs
@@ -351,6 +351,10 @@ impl<F: PrimeField32> RwasmAir<F> {
         costs.insert(div_rem.name(), div_rem.cost());
         chips.push(div_rem);
 
+        let rotate = Chip::new(RwasmAir::Rotate(RotateChip::default()));
+        costs.insert(rotate.name(), rotate.cost());
+        chips.push(rotate);
+
         let add_sub = Chip::new(RwasmAir::Add(AddSubChip::default()));
         costs.insert(add_sub.name(), add_sub.cost());
         chips.push(add_sub);
@@ -370,10 +374,6 @@ impl<F: PrimeField32> RwasmAir<F> {
         let shift_left = Chip::new(RwasmAir::ShiftLeft(ShiftLeft::default()));
         costs.insert(shift_left.name(), shift_left.cost());
         chips.push(shift_left);
-
-        let rotate = Chip::new(RwasmAir::Rotate(RotateChip::default()));
-        costs.insert(rotate.name(), rotate.cost());
-        chips.push(rotate);
 
         let lt = Chip::new(RwasmAir::Lt(LtChip::default()));
         costs.insert(lt.name(), lt.cost());

--- a/crates/rwasm/machine/src/shape/mod.rs
+++ b/crates/rwasm/machine/src/shape/mod.rs
@@ -595,6 +595,9 @@ fn derive_cluster_from_maximal_shape(shape: &Shape<RwasmAirId>) -> ShapeCluster<
     let bitwise_log_height = shape.log2_height(&RwasmAirId::Bitwise);
     maybe_log2_heights.insert(RwasmAirId::Bitwise, heuristic(bitwise_log_height, 1));
 
+    let rotate_log_height = shape.log2_height(&RwasmAirId::Rotate);
+    maybe_log2_heights.insert(RwasmAirId::Rotate, heuristic(rotate_log_height, 1));
+
     let mul_log_height = shape.log2_height(&RwasmAirId::Mul);
     maybe_log2_heights.insert(RwasmAirId::Mul, heuristic(mul_log_height, 1));
 

--- a/crates/rwasm/machine/src/shape/shapeable.rs
+++ b/crates/rwasm/machine/src/shape/shapeable.rs
@@ -55,6 +55,7 @@ impl Shapeable for ExecutionRecord {
             (RwasmAirId::DivRem, self.divrem_events.len()),
             (RwasmAirId::AddSub, self.add_events.len() + self.sub_events.len()),
             (RwasmAirId::Bitwise, self.bitwise_events.len()),
+            (RwasmAirId::Rotate, self.rotate_events.len()),
             (RwasmAirId::Mul, self.mul_events.len()),
             (RwasmAirId::ShiftRight, self.shift_right_events.len()),
             (RwasmAirId::ShiftLeft, self.shift_left_events.len()),

--- a/crates/rwasm/prover/src/gas/model.rs
+++ b/crates/rwasm/prover/src/gas/model.rs
@@ -1,6 +1,6 @@
 use itertools::izip;
 
-pub const INPUT_SIZE: usize = 94; //TODO: find why this is 90
+pub const INPUT_SIZE: usize = 96; //TODO: find why this is 90
 
 pub fn predict(input: &[usize; INPUT_SIZE / 2]) -> f64 {
     let input = [input.map(|x| x as f64), input.map(|x| 2f64.powi(x.try_into().unwrap()))].concat();
@@ -122,6 +122,8 @@ pub(crate) const PARAMS: Params<INPUT_SIZE> = Params {
         0.0,
         0.0,
         0.0,
+        0.0,
+        0.0,
     ],
     std: [
         7.185413671836201,
@@ -218,6 +220,8 @@ pub(crate) const PARAMS: Params<INPUT_SIZE> = Params {
         0.0,
         0.0,
         0.0,
+        0.0,
+        0.0,
     ],
     coefs: [
         3.4394572520867,
@@ -309,6 +313,8 @@ pub(crate) const PARAMS: Params<INPUT_SIZE> = Params {
         60.515898660880275,
         88.22315498928933,
         296.047004079781,
+        0.0,
+        0.0,
         0.0,
         0.0,
         0.0,

--- a/crates/rwasm/prover/src/rwasmtest/mod.rs
+++ b/crates/rwasm/prover/src/rwasmtest/mod.rs
@@ -1,5 +1,7 @@
 mod comp;
+mod rotate;
 mod table_init;
+
 use rwasm_executor::Program;
 use rwasm_machine::utils::setup_logger;
 
@@ -14,6 +16,8 @@ pub fn run_rwasm_prover(mut program: Program) {
 
     tracing::info!("setup elf");
     let (_, pk, vk) = prover.setup_program(&mut program);
+
+    println!("setup_program {:?}", program);
 
     tracing::info!("prove core");
     let stdin = SP1Stdin::new();

--- a/crates/rwasm/prover/src/rwasmtest/rotate.rs
+++ b/crates/rwasm/prover/src/rwasmtest/rotate.rs
@@ -2,9 +2,16 @@
 
 use crate::rwasmtest::run_rwasm_prover;
 use rwasm_executor::{Opcode, Program};
+use rwasm_machine::{
+    io::SP1Stdin,
+    rwasm::RwasmAir,
+    utils::{run_test, setup_logger},
+};
+use sp1_stark::CpuProver;
 
 #[test]
 fn test_i32_rotl() {
+    setup_logger();
     let program = Program::from_instrs(vec![
         Opcode::I32Const(2u32.into()),
         Opcode::I32Const(1u32.into()),
@@ -21,6 +28,7 @@ fn test_i32_rotl() {
 
 #[test]
 fn test_i32_rotr() {
+    setup_logger();
     let program = Program::from_instrs(vec![
         Opcode::I32Const(2u32.into()),
         Opcode::I32Const(1u32.into()),

--- a/crates/rwasm/prover/src/rwasmtest/rotate.rs
+++ b/crates/rwasm/prover/src/rwasmtest/rotate.rs
@@ -1,0 +1,36 @@
+// In crates/rwasm/prover/src/rwasmtest/rotate.rs
+
+use crate::rwasmtest::run_rwasm_prover;
+use rwasm_executor::{Opcode, Program};
+
+#[test]
+fn test_i32_rotl() {
+    let program = Program::from_instrs(vec![
+        Opcode::I32Const(2u32.into()),
+        Opcode::I32Const(1u32.into()),
+        Opcode::I32Const(1u32.into()),
+        Opcode::I32Shl,
+        Opcode::I32ShrU,
+        // The actual test program for rotation.
+        Opcode::I32Const(0x12345678u32.into()),
+        Opcode::I32Const(5u32.into()),
+        Opcode::I32Rotl,
+    ]);
+    run_rwasm_prover(program);
+}
+
+#[test]
+fn test_i32_rotr() {
+    let program = Program::from_instrs(vec![
+        Opcode::I32Const(2u32.into()),
+        Opcode::I32Const(1u32.into()),
+        Opcode::I32Const(1u32.into()),
+        Opcode::I32Shl,
+        Opcode::I32ShrU,
+        // The actual test program for rotation.
+        Opcode::I32Const(0x12345678u32.into()),
+        Opcode::I32Const(5u32.into()),
+        Opcode::I32Rotr,
+    ]);
+    run_rwasm_prover(program);
+}

--- a/crates/rwasm/prover/src/types.rs
+++ b/crates/rwasm/prover/src/types.rs
@@ -34,7 +34,7 @@ pub struct SP1ProvingKey {
 }
 
 /// The information necessary to verify a proof for a given RISC-V program.
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct SP1VerifyingKey {
     pub vk: StarkVerifyingKey<CoreSC>,
 }


### PR DESCRIPTION
…hifts proof

Implement 32-bit rotations by decomposing each op into two shifts plus a bitwise OR:
	•	rotl(x,k) = (x << k) | (x >> (32 - k))
	•	rotr(x,k) = (x >> k) | (x << (32 - k))
In the ZK constraints, prove correctness by constraining the left/right shift contributions and their bytewise OR to equal the result; mask k to 5 bits (k = c & 31) and use 32 - k as the inverse.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Typos / punctuation / trivial PRs are generally not accepted.

Contributors guide: https://github.com/succinctlabs/sp1/blob/dev/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ X] Added Tests
- [ ] Added Documentation
- [ X] Breaking changes