### PR TITLE
feat(alu): Implement Mul64Chip to prove I32Mul64 operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ checksum = "64b728d511962dda67c1bc7ea7c03736ec275ed2cf4c35d9585298ac9ccf3b73"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -408,7 +408,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -424,7 +424,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
  "syn-solidity",
  "tiny-keccak",
 ]
@@ -441,7 +441,7 @@ dependencies = [
  "macro-string",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
  "syn-solidity",
 ]
 
@@ -745,7 +745,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -783,7 +783,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -897,7 +897,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1095,7 +1095,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1125,7 +1125,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1165,7 +1165,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1341,7 +1341,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1507,7 +1507,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1598,16 +1598,16 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.108",
+ "syn 2.0.110",
  "tempfile",
  "toml",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.44"
+version = "1.2.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37521ac7aabe3d13122dc382493e20c9416f299d2ccd5b3a5340a2570cdeb0f3"
+checksum = "35900b6c8d709fb1d854671ae27aeaa9eec2f8b01b364e1619a40da3e6fe2afe"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1725,7 +1725,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2193,9 +2193,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.83+curl-8.15.0"
+version = "0.4.84+curl-8.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5830daf304027db10c82632a464879d46a3f7c4ba17a31592657ad16c719b483"
+checksum = "abc4294dc41b882eaff37973c2ec3ae203d0091341ee68fbadd1d06e0c18a73b"
 dependencies = [
  "cc",
  "libc",
@@ -2386,7 +2386,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2397,7 +2397,7 @@ checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
  "unicode-xid",
 ]
 
@@ -2490,7 +2490,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2549,7 +2549,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2643,7 +2643,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2663,7 +2663,7 @@ checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2839,7 +2839,7 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 [[package]]
 name = "fluentbase-types"
 version = "0.4.11-dev"
-source = "git+https://github.com/fluentlabs-xyz/fluentbase.git?branch=devel#193b0b8ee8740616400f43b99c0f54a337a420a0"
+source = "git+https://github.com/fluentlabs-xyz/fluentbase.git?branch=devel#087966dfbc1645ff34b6d988ec825485e4c4e549"
 dependencies = [
  "alloy-primitives 1.4.1",
  "bincode 2.0.1",
@@ -2995,7 +2995,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -3515,7 +3515,7 @@ dependencies = [
  "http 1.3.1",
  "hyper",
  "hyper-util",
- "rustls 0.23.34",
+ "rustls 0.23.35",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -3733,7 +3733,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -3806,9 +3806,9 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "iri-string"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+checksum = "4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397"
 dependencies = [
  "memchr",
  "serde",
@@ -4130,7 +4130,7 @@ checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -4346,7 +4346,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -4454,7 +4454,7 @@ checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -4545,9 +4545,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.74"
+version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ad14dd45412269e1a30f52ad8f0664f0f4f4a89ee8fe28c3b3527021ebb654"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -4566,7 +4566,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -4577,9 +4577,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.110"
+version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a9f0075ba3c21b09f8e8b2026584b1d18d49388648f2fbbf3c97ea8deced8e2"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
@@ -4887,7 +4887,7 @@ dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -5013,7 +5013,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -5163,7 +5163,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -5224,7 +5224,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -5287,7 +5287,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.108",
+ "syn 2.0.110",
  "tempfile",
 ]
 
@@ -5301,7 +5301,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -5341,7 +5341,7 @@ source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=devel#e7833300b1
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -5362,7 +5362,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls 0.23.34",
+ "rustls 0.23.35",
  "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
@@ -5382,7 +5382,7 @@ dependencies = [
  "rand 0.9.2",
  "ring 0.17.14",
  "rustc-hash 2.1.1",
- "rustls 0.23.34",
+ "rustls 0.23.35",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.17",
@@ -5407,9 +5407,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.41"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
@@ -5666,7 +5666,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.34",
+ "rustls 0.23.35",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -5946,9 +5946,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.34"
+version = "0.23.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9586e9ee2b4f8fab52a0048ca7334d7024eef48e2cb9407e3497bb7cab7fa7"
+checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
 dependencies = [
  "log",
  "once_cell",
@@ -6022,7 +6022,7 @@ dependencies = [
 [[package]]
 name = "rwasm"
 version = "0.0.0"
-source = "git+https://github.com/fluentlabs-xyz/rwasm.git?branch=feat%2Ftracing#af1b5e2043c63c68dcb5c23acd957dd43c06d933"
+source = "git+https://github.com/fluentlabs-xyz/rwasm.git?branch=feat%2Ftracing#8a3dd099f23da995e2cf991f4a7c1c9ae77a2311"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -6309,7 +6309,7 @@ dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -6353,7 +6353,7 @@ checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -6493,7 +6493,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -6606,7 +6606,7 @@ checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -7467,7 +7467,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -7479,7 +7479,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -7491,7 +7491,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -7566,9 +7566,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.108"
+version = "2.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da58917d35242480a05c2897064da0a80589a2a0476c9a3f2fdc83b53502e917"
+checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7584,7 +7584,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -7604,7 +7604,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -7710,7 +7710,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -7721,7 +7721,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -7880,7 +7880,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -7899,7 +7899,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.34",
+ "rustls 0.23.35",
  "tokio",
 ]
 
@@ -8153,7 +8153,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -8235,7 +8235,7 @@ checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -8561,7 +8561,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
  "wasm-bindgen-shared",
 ]
 
@@ -8790,7 +8790,7 @@ dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
  "wit-parser",
@@ -8910,7 +8910,7 @@ source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=devel#e7833300b1
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -9100,7 +9100,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -9111,7 +9111,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -9480,7 +9480,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
  "synstructure",
 ]
 
@@ -9501,7 +9501,7 @@ checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -9521,7 +9521,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
  "synstructure",
 ]
 
@@ -9542,7 +9542,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -9575,7 +9575,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]

--- a/crates/rwasm/executor/Cargo.toml
+++ b/crates/rwasm/executor/Cargo.toml
@@ -49,7 +49,7 @@ range-set-blaze = "0.1.16"
 
 # rwasm
 fluentbase-types = { git = "https://github.com/fluentlabs-xyz/fluentbase.git", "branch" = "devel", default-features = false }
-rwasm = { git = "https://github.com/fluentlabs-xyz/rwasm.git", branch = "feat/tracing", features = [
+rwasm = { git = "https://github.com/fluentlabs-xyz/rwasm.git", branch = "feat/tracing-i64", features = [
     "std",
     "tracing",
 ] }
@@ -76,3 +76,4 @@ profiling = [
 
 [lints]
 workspace = true
+

--- a/crates/rwasm/executor/Cargo.toml
+++ b/crates/rwasm/executor/Cargo.toml
@@ -49,7 +49,7 @@ range-set-blaze = "0.1.16"
 
 # rwasm
 fluentbase-types = { git = "https://github.com/fluentlabs-xyz/fluentbase.git", "branch" = "devel", default-features = false }
-rwasm = { git = "https://github.com/fluentlabs-xyz/rwasm.git", branch = "feat/tracing-i64", features = [
+rwasm = { git = "https://github.com/fluentlabs-xyz/rwasm.git", branch = "feat/tracing", features = [
     "std",
     "tracing",
 ] }

--- a/crates/rwasm/executor/src/air.rs
+++ b/crates/rwasm/executor/src/air.rs
@@ -155,6 +155,9 @@ pub enum RwasmAirId {
 
     #[subenum(CoreAirId)]
     Trailing = 49,
+
+    #[subenum(CoreAirId)]
+    Mul64 = 50,
 }
 
 impl RwasmAirId {

--- a/crates/rwasm/executor/src/artifacts/rv32im_costs.json
+++ b/crates/rwasm/executor/src/artifacts/rv32im_costs.json
@@ -48,5 +48,6 @@
   "Rotate": 256,
   "TableInit": 10000,
   "TableGrow": 10000,
-  "Trailing": 256
+  "Trailing": 256,
+  "Mul64": 166
 }

--- a/crates/rwasm/executor/src/events/cpu.rs
+++ b/crates/rwasm/executor/src/events/cpu.rs
@@ -26,6 +26,12 @@ pub struct CpuEvent {
     pub res_record: Option<MemoryRecordEnum>,
     /// addr for operand result
     pub res_addr: Option<TypedAddress>,
+    /// The first operand.
+    pub res_hi: u32,
+    /// The first operand memory record.
+    pub res_hi_record: Option<MemoryRecordEnum>,
+    /// addr for operand result
+    pub res_hi_addr: Option<TypedAddress>,
     /// The second operand.
     pub arg1: u32,
     /// The second operand memory record.

--- a/crates/rwasm/executor/src/events/instr.rs
+++ b/crates/rwasm/executor/src/events/instr.rs
@@ -223,3 +223,47 @@ impl CallEvent {
         }
     }
 }
+
+/// Alu Opcode Event.
+///
+/// This object encapsulated the information needed to prove a RISC-V ALU operation.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[repr(C)]
+pub struct I64AluEvent {
+    /// The program counter.
+    pub pc: u32,
+    /// riscv opcode
+    pub opcode: Opcode,
+    /// The result value
+    pub a: u32,
+    /// The result value's hi bits
+    pub a_hi: u32,
+    /// The second operand value.
+    pub b: u32,
+    /// The third operand value.
+    pub c: u32,
+    /// u32 representation of Opcode
+    pub code: u32,
+
+    pub res_hi_addr: u32,
+
+    pub res_hi_access: Option<MemoryRecordEnum>,
+}
+
+impl I64AluEvent {
+    /// Create a new [`AluEvent`].
+    #[must_use]
+    pub fn new(
+        pc: u32,
+        opcode: Opcode,
+        a: u32,
+        a_hi: u32,
+        b: u32,
+        c: u32,
+        code: u32,
+        res_hi_addr: u32,
+        res_hi_access: Option<MemoryRecordEnum>,
+    ) -> Self {
+        Self { pc, opcode, a, a_hi, b, c, code, res_hi_addr, res_hi_access }
+    }
+}

--- a/crates/rwasm/executor/src/events/instr.rs
+++ b/crates/rwasm/executor/src/events/instr.rs
@@ -235,7 +235,7 @@ pub struct I64AluEvent {
     /// riscv opcode
     pub opcode: Opcode,
     /// The result value
-    pub a: u32,
+    pub a_lo: u32,
     /// The result value's hi bits
     pub a_hi: u32,
     /// The second operand value.
@@ -265,6 +265,6 @@ impl I64AluEvent {
         res_hi_addr: u32,
         res_hi_access: Option<MemoryRecordEnum>,
     ) -> Self {
-        Self { pc, opcode, a, a_hi, b, c, code, res_hi_addr, res_hi_access }
+        Self { pc, opcode, a_lo: a, a_hi, b, c, code, res_hi_addr, res_hi_access }
     }
 }

--- a/crates/rwasm/executor/src/executor.rs
+++ b/crates/rwasm/executor/src/executor.rs
@@ -1203,7 +1203,13 @@ impl<'a> Executor<'a> {
             res_hi_addr: memory_access.res_hi_addr.unwrap().to_virtual_addr(),
             res_hi_access: memory_access.res_hi_record,
         };
-        self.record.i64_events.push(event);
+        match opcode {
+            Opcode::I32Mul64 => self.record.mul64_events.push(event),
+            Opcode::I32Add64 => self.record.add64_events.push(event),
+            _ => {
+                unreachable!();
+            }
+        }
     }
 
     /// Execute an ecall opcode.
@@ -5301,9 +5307,7 @@ mod tests {
             let mut rt = Executor::new(program, SP1CoreOpts::default());
             rt.run().unwrap();
 
-            let prod = ((a as i32) as i64).wrapping_mul((b as i32) as i64);
-            // let prod = (a as i64).wrapping_mul(b as i64);
-
+            let prod = (a as i64).wrapping_mul(b as i64);
             let (lo, hi) = prod.split_into_i32_tuple();
 
             // After 64-bit ops, convention is: top-of-stack = HI, next = LO (see test_i32add64).

--- a/crates/rwasm/executor/src/executor.rs
+++ b/crates/rwasm/executor/src/executor.rs
@@ -3,7 +3,7 @@ use crate::profiler::Profiler;
 use crate::{
     dependencies::{emit_branch_dependencies, emit_divrem_dependencies, emit_memory_dependencies},
     estimator::RecordEstimator,
-    events::{CallEvent, ConstEvent, PrecompileEvent, SysStateEvent, SyscallEvent},
+    events::{CallEvent, ConstEvent, I64AluEvent, PrecompileEvent, SyscallEvent},
 };
 #[cfg(feature = "profiling")]
 use std::{fs::File, io::BufWriter};
@@ -711,6 +711,7 @@ impl<'a> Executor<'a> {
         arg1: u32,
         arg2: u32,
         res: u32,
+        res_hi: u32,
         record: MemoryAccessRecord,
         call_data: Option<TraceCallData>,
         fat_op: Option<FatOpEvent>,
@@ -812,6 +813,8 @@ impl<'a> Executor<'a> {
                     );
                 }
             }
+        } else if opcode.is_64b_op() {
+            self.emit_i64_event(clk, pc, next_pc, opcode, res, res_hi, arg1, arg2, record);
         } else {
             println!("no event :ins:{:?},", opcode);
         }
@@ -1164,19 +1167,33 @@ impl<'a> Executor<'a> {
         self.record.call_events.push(event);
     }
 
-    // Emit a branch event.
+    #[allow(clippy::too_many_arguments)]
     #[inline]
-    #[allow(dead_code)]
-    fn emit_sys_state_event(
+    fn emit_i64_event(
         &mut self,
+
+        clk: u32,
+        pc: u32,
+        next_pc: u32,
         opcode: Opcode,
-        fuel: u32,
-        next_fuel: u32,
-        max_memory: u32,
-        next_max_memory: u32,
+        res: u32,
+        res_hi: u32,
+        arg1: u32,
+        arg2: u32,
+        memory_access: MemoryAccessRecord,
     ) {
-        let event = SysStateEvent::new(opcode, fuel, next_fuel, max_memory, next_max_memory);
-        self.record.sys_state_events.push(event);
+        let event = I64AluEvent {
+            pc,
+            opcode,
+            a: res,
+            a_hi: res_hi,
+            b: arg1,
+            c: arg2,
+            code: opcode.code(),
+            res_hi_addr: memory_access.res_hi_addr.unwrap().to_virtual_addr(),
+            res_hi_access: memory_access.res_hi_record,
+        };
+        self.record.i64_events.push(event);
     }
 
     /// Execute an ecall opcode.
@@ -1307,6 +1324,7 @@ impl<'a> Executor<'a> {
             syscall,
             op_state.arg1,
             op_state.arg2,
+            op_state.res,
             op_state.res,
             op_state.memory_access,
             op_state.call_state,
@@ -5147,5 +5165,22 @@ mod tests {
 
         let top = rt.state.memory.get(rt.state.sp).unwrap().value;
         assert_eq!(top, a.trailing_zeros(), "incorrect count zeros");
+    }
+
+    #[test]
+    fn test_i32add64() {
+        let sp0 = SP_START;
+        let opcodes = vec![
+            Opcode::I32Const(u32::MAX.into()),
+            Opcode::I32Const(1u32.into()),
+            Opcode::I32Add64, // wraps to 0
+        ];
+        let program = Program::from_instrs(opcodes);
+        let mut rt = Executor::new(program, SP1CoreOpts::default());
+        rt.run().unwrap();
+
+        assert_eq!(rt.state.memory.get(rt.state.sp).unwrap().value, 1);
+        assert_eq!(rt.state.memory.get(rt.state.sp + 4).unwrap().value, 0);
+        assert_eq!(sp0, rt.state.sp);
     }
 }

--- a/crates/rwasm/executor/src/executor.rs
+++ b/crates/rwasm/executor/src/executor.rs
@@ -5138,10 +5138,7 @@ mod tests {
     fn test_i32popcnt() {
         fn check(a: u32) {
             let sp0 = SP_START;
-            let program = Program::from_instrs(vec![
-                Opcode::I32Const(a.into()),
-                Opcode::I32Popcnt,
-            ]);
+            let program = Program::from_instrs(vec![Opcode::I32Const(a.into()), Opcode::I32Popcnt]);
 
             let mut rt = Executor::new(program, SP1CoreOpts::default());
             rt.run().unwrap();
@@ -5154,15 +5151,15 @@ mod tests {
         }
 
         // Edge cases
-        check(0x0000_0000);        // 0
-        check(0xFFFF_FFFF);        // 32
-        check(0x0000_0001);        // 1
-        check(0x8000_0000);        // 1
-        check(0x7FFF_FFFF);        // 31
+        check(0x0000_0000); // 0
+        check(0xFFFF_FFFF); // 32
+        check(0x0000_0001); // 1
+        check(0x8000_0000); // 1
+        check(0x7FFF_FFFF); // 31
 
         // Patterns
-        check(0xAAAA_AAAA);        // 16 ones
-        check(0x5555_5555);        // 16 ones
+        check(0xAAAA_AAAA); // 16 ones
+        check(0x5555_5555); // 16 ones
 
         // Random-ish sanity values
         check(0x0137_0137);
@@ -5172,10 +5169,7 @@ mod tests {
     fn test_i32clz() {
         fn check(a: u32) {
             let sp0 = SP_START;
-            let program = Program::from_instrs(vec![
-                Opcode::I32Const(a.into()),
-                Opcode::I32Clz,
-            ]);
+            let program = Program::from_instrs(vec![Opcode::I32Const(a.into()), Opcode::I32Clz]);
 
             let mut rt = Executor::new(program, SP1CoreOpts::default());
             rt.run().unwrap();
@@ -5206,10 +5200,7 @@ mod tests {
     fn test_i32ctz() {
         fn check(a: u32) {
             let sp0 = SP_START;
-            let program = Program::from_instrs(vec![
-                Opcode::I32Const(a.into()),
-                Opcode::I32Ctz,
-            ]);
+            let program = Program::from_instrs(vec![Opcode::I32Const(a.into()), Opcode::I32Ctz]);
 
             let mut rt = Executor::new(program, SP1CoreOpts::default());
             rt.run().unwrap();
@@ -5274,15 +5265,15 @@ mod tests {
         }
 
         // Basic and edge cases
-        check(0, 0);                            // 0 + 0 -> (hi=0, lo=0)
-        check(u32::MAX, 0);                     // max + 0
-        check(u32::MAX, 1);                     // carry into HI -> (hi=1, lo=0)
-        check(u32::MAX, u32::MAX);              // 0xFFFF_FFFF + 0xFFFF_FFFF -> (hi=1, lo=0xFFFF_FFFE)
-        check(0x7FFF_FFFF, 1);                  // boundary without HI carry -> (hi=0, lo=0x8000_0000)
+        check(0, 0); // 0 + 0 -> (hi=0, lo=0)
+        check(u32::MAX, 0); // max + 0
+        check(u32::MAX, 1); // carry into HI -> (hi=1, lo=0)
+        check(u32::MAX, u32::MAX); // 0xFFFF_FFFF + 0xFFFF_FFFF -> (hi=1, lo=0xFFFF_FFFE)
+        check(0x7FFF_FFFF, 1); // boundary without HI carry -> (hi=0, lo=0x8000_0000)
 
         // Cross terms around the carry boundary
-        check(0xFFFF_0000, 0x0000_FFFF);        // no HI carry -> (hi=0, lo=0xFFFF_FFFF)
-        check(0xFFFF_0001, 0x0000_FFFF);        // exact 2^32 -> (hi=1, lo=0)
+        check(0xFFFF_0000, 0x0000_FFFF); // no HI carry -> (hi=0, lo=0xFFFF_FFFF)
+        check(0xFFFF_0001, 0x0000_FFFF); // exact 2^32 -> (hi=1, lo=0)
 
         // Symmetry / commutativity sanity
         check(0x1234_5678, 0x9ABC_DEF0);
@@ -5324,14 +5315,13 @@ mod tests {
         }
 
         // Edge & sanity cases
-        check(0, 0);                          // zero * zero
-        check(u32::MAX, 1);                   // max * 1
-        check(u32::MAX, u32::MAX);            // max * max -> hi = 0xFFFF_FFFE, lo = 1
-        check(0x8000_0000, 2);                // 2^31 * 2 = 2^32 -> hi=1, lo=0
-        check(0xFFFF_0000, 0x0000_FFFF);      // cross terms
-        // Random-ish sanity and commutativity
+        check(0, 0); // zero * zero
+        check(u32::MAX, 1); // max * 1
+        check(u32::MAX, u32::MAX); // max * max -> hi = 0xFFFF_FFFE, lo = 1
+        check(0x8000_0000, 2); // 2^31 * 2 = 2^32 -> hi=1, lo=0
+        check(0xFFFF_0000, 0x0000_FFFF); // cross terms
+                                         // Random-ish sanity and commutativity
         check(0x1234_5678, 0x9ABC_DEF0);
         check(0x9ABC_DEF0, 0x1234_5678);
     }
-
 }

--- a/crates/rwasm/executor/src/executor.rs
+++ b/crates/rwasm/executor/src/executor.rs
@@ -1183,7 +1183,7 @@ impl<'a> Executor<'a> {
         pc: u32,
         next_pc: u32,
         opcode: Opcode,
-        res: u32,
+        res_lo: u32,
         res_hi: u32,
         arg1: u32,
         arg2: u32,
@@ -1192,7 +1192,7 @@ impl<'a> Executor<'a> {
         let event = I64AluEvent {
             pc,
             opcode,
-            a: res,
+            a_lo: res_lo,
             a_hi: res_hi,
             b: arg1,
             c: arg2,

--- a/crates/rwasm/executor/src/executor.rs
+++ b/crates/rwasm/executor/src/executor.rs
@@ -729,6 +729,7 @@ impl<'a> Executor<'a> {
                 arg1,
                 opcode.aux_value(),
                 arg2,
+                res_hi,
                 record,
                 0u32,
                 call_data,
@@ -745,6 +746,7 @@ impl<'a> Executor<'a> {
                 arg1,
                 arg2,
                 res,
+                res_hi,
                 record,
                 0u32,
                 call_data,
@@ -814,6 +816,7 @@ impl<'a> Executor<'a> {
                 }
             }
         } else if opcode.is_64b_op() {
+            println!("emit_i64_event cpu");
             self.emit_i64_event(clk, pc, next_pc, opcode, res, res_hi, arg1, arg2, record);
         } else {
             println!("no event :ins:{:?},", opcode);
@@ -835,6 +838,7 @@ impl<'a> Executor<'a> {
         arg1: u32,
         arg2: u32,
         res: u32,
+        res_hi: u32,
         record: MemoryAccessRecord,
         exit_code: u32,
         call_data: Option<TraceCallData>,
@@ -850,6 +854,9 @@ impl<'a> Executor<'a> {
             res,
             res_record: record.res_record,
             res_addr: record.res_addr,
+            res_hi,
+            res_hi_record: record.res_hi_record,
+            res_hi_addr: record.res_hi_addr,
             arg1,
             arg1_record: record.arg1_record,
             arg1_addr: record.arg1_addr,
@@ -1325,7 +1332,7 @@ impl<'a> Executor<'a> {
             op_state.arg1,
             op_state.arg2,
             op_state.res,
-            op_state.res,
+            op_state.res_hi,
             op_state.memory_access,
             op_state.call_state,
             op_state.fat_op.clone(),
@@ -2012,7 +2019,7 @@ mod tests {
 
     use rwasm::{
         mem_index::{TypedAddress, SP_START, UNIT},
-        BranchOffset, Opcode,
+        BranchOffset, I64ValueSplit, Opcode,
     };
     use sp1_stark::SP1CoreOpts;
 
@@ -5291,21 +5298,22 @@ mod tests {
             let mut rt = Executor::new(program, SP1CoreOpts::default());
             rt.run().unwrap();
 
-            let prod = (a as u64).wrapping_mul(b as u64);
-            let lo = (prod & 0xFFFF_FFFF) as u32;
-            let hi = (prod >> 32) as u32;
+            let prod = ((a as i32) as i64).wrapping_mul((b as i32) as i64);
+            // let prod = (a as i64).wrapping_mul(b as i64);
+
+            let (lo, hi) = prod.split_into_i32_tuple();
 
             // After 64-bit ops, convention is: top-of-stack = HI, next = LO (see test_i32add64).
             assert_eq!(
                 rt.state.memory.get(rt.state.sp).unwrap().value,
-                hi,
+                hi as u32,
                 "HI mismatch for a={:#x}, b={:#x}",
                 a,
                 b
             );
             assert_eq!(
                 rt.state.memory.get(rt.state.sp + 4).unwrap().value,
-                lo,
+                lo as u32,
                 "LO mismatch for a={:#x}, b={:#x}",
                 a,
                 b

--- a/crates/rwasm/executor/src/executor.rs
+++ b/crates/rwasm/executor/src/executor.rs
@@ -5115,6 +5115,7 @@ mod tests {
     }
     #[test]
     fn test_i32rot() {
+        let sp0 = SP_START;
         let b: u32 = 0x8000_0001u32;
         let c: u32 = 7u32;
         let program = Program::from_instrs(vec![
@@ -5130,57 +5131,206 @@ mod tests {
 
         let top = rt.state.memory.get(rt.state.sp).unwrap().value;
         assert_eq!(top, b, "recovery result mismatch");
+        assert_eq!(sp0, rt.state.sp + UNIT);
     }
 
     #[test]
     fn test_i32popcnt() {
-        let a: u32 = 0x137_137;
-        let program = Program::from_instrs(vec![Opcode::I32Const(a.into()), Opcode::I32Popcnt]);
+        fn check(a: u32) {
+            let sp0 = SP_START;
+            let program = Program::from_instrs(vec![
+                Opcode::I32Const(a.into()),
+                Opcode::I32Popcnt,
+            ]);
 
-        let mut rt = Executor::new(program, SP1CoreOpts::default());
-        rt.run().unwrap();
+            let mut rt = Executor::new(program, SP1CoreOpts::default());
+            rt.run().unwrap();
 
-        let top = rt.state.memory.get(rt.state.sp).unwrap().value;
-        assert_eq!(top, a.count_ones(), "incorrect count ones");
+            let expected = a.count_ones();
+            let top = rt.state.memory.get(rt.state.sp).unwrap().value;
+            assert_eq!(top, expected, "I32Popcnt result mismatch for a={:#x}", a);
+            // One 32-bit value pushed
+            assert_eq!(sp0, rt.state.sp + UNIT);
+        }
+
+        // Edge cases
+        check(0x0000_0000);        // 0
+        check(0xFFFF_FFFF);        // 32
+        check(0x0000_0001);        // 1
+        check(0x8000_0000);        // 1
+        check(0x7FFF_FFFF);        // 31
+
+        // Patterns
+        check(0xAAAA_AAAA);        // 16 ones
+        check(0x5555_5555);        // 16 ones
+
+        // Random-ish sanity values
+        check(0x0137_0137);
+        check(0xDEAD_BEEF);
     }
     #[test]
     fn test_i32clz() {
-        //count leading zeros
-        let a: u32 = 0x137_137;
-        let program = Program::from_instrs(vec![Opcode::I32Const(a.into()), Opcode::I32Clz]);
+        fn check(a: u32) {
+            let sp0 = SP_START;
+            let program = Program::from_instrs(vec![
+                Opcode::I32Const(a.into()),
+                Opcode::I32Clz,
+            ]);
 
-        let mut rt = Executor::new(program, SP1CoreOpts::default());
-        rt.run().unwrap();
+            let mut rt = Executor::new(program, SP1CoreOpts::default());
+            rt.run().unwrap();
 
-        let top = rt.state.memory.get(rt.state.sp).unwrap().value;
-        assert_eq!(top, a.leading_zeros(), "incorrect count zeros");
+            let expected = a.leading_zeros(); // WASM spec: clz(0) = 32
+            let top = rt.state.memory.get(rt.state.sp).unwrap().value;
+            assert_eq!(top, expected, "I32Clz result mismatch for a={:#x}", a);
+            // One 32-bit value pushed
+            assert_eq!(sp0, rt.state.sp + UNIT);
+        }
+
+        // Edge cases
+        check(0x0000_0000); // 32
+        check(0x0000_0001); // 31
+        check(0x8000_0000); // 0
+
+        // Boundary & pattern cases
+        check(0x0000_FFFF); // 16
+        check(0x00F0_0000); // 8
+        check(0x7FFF_FFFF); // 1
+        check(0xFFFF_0000); // 0
+
+        // Random-ish sanity values
+        check(0x0137_0137);
+        check(0xDEAD_BEEF);
     }
     #[test]
     fn test_i32ctz() {
-        let a: u32 = 0x137_137;
-        let program = Program::from_instrs(vec![Opcode::I32Const(a.into()), Opcode::I32Ctz]);
+        fn check(a: u32) {
+            let sp0 = SP_START;
+            let program = Program::from_instrs(vec![
+                Opcode::I32Const(a.into()),
+                Opcode::I32Ctz,
+            ]);
 
-        let mut rt = Executor::new(program, SP1CoreOpts::default());
-        rt.run().unwrap();
+            let mut rt = Executor::new(program, SP1CoreOpts::default());
+            rt.run().unwrap();
 
-        let top = rt.state.memory.get(rt.state.sp).unwrap().value;
-        assert_eq!(top, a.trailing_zeros(), "incorrect count zeros");
+            let expected = a.trailing_zeros(); // Rust matches WASM semantics: ctz(0) = 32
+            let top = rt.state.memory.get(rt.state.sp).unwrap().value;
+            assert_eq!(top, expected, "I32Ctz result mismatch for a={:#x}", a);
+            // One 32-bit value pushed
+            assert_eq!(sp0, rt.state.sp + UNIT);
+        }
+
+        // Edge cases
+        check(0x0000_0000); // ctz(0) = 32
+        check(0x0000_0001); // 0
+        check(0x0000_0002); // 1
+        check(0x0000_0004); // 2
+        check(0x8000_0000); // 31
+
+        // Boundary & pattern cases
+        check(0x0001_0000); // 16
+        check(0xFFFF_0000); // 16 (low half zero)
+        check(0x00F0_0000); // 20
+
+        // Random-ish sanity values
+        check(0x0137_0137);
+        check(0xDEAD_BEEF);
     }
 
     #[test]
     fn test_i32add64() {
-        let sp0 = SP_START;
-        let opcodes = vec![
-            Opcode::I32Const(u32::MAX.into()),
-            Opcode::I32Const(1u32.into()),
-            Opcode::I32Add64, // wraps to 0
-        ];
-        let program = Program::from_instrs(opcodes);
-        let mut rt = Executor::new(program, SP1CoreOpts::default());
-        rt.run().unwrap();
+        fn check(a: u32, b: u32) {
+            let sp0 = SP_START;
+            let program = Program::from_instrs(vec![
+                Opcode::I32Const(a.into()),
+                Opcode::I32Const(b.into()),
+                Opcode::I32Add64,
+            ]);
+            let mut rt = Executor::new(program, SP1CoreOpts::default());
+            rt.run().unwrap();
 
-        assert_eq!(rt.state.memory.get(rt.state.sp).unwrap().value, 1);
-        assert_eq!(rt.state.memory.get(rt.state.sp + 4).unwrap().value, 0);
-        assert_eq!(sp0, rt.state.sp);
+            let sum = (a as u64) + (b as u64);
+            let lo = (sum & 0xFFFF_FFFF) as u32;
+            let hi = (sum >> 32) as u32;
+
+            // Convention for 64-bit ops: top-of-stack = HI, next = LO.
+            assert_eq!(
+                rt.state.memory.get(rt.state.sp).unwrap().value,
+                hi,
+                "HI mismatch for a={:#x}, b={:#x}",
+                a,
+                b
+            );
+            assert_eq!(
+                rt.state.memory.get(rt.state.sp + 4).unwrap().value,
+                lo,
+                "LO mismatch for a={:#x}, b={:#x}",
+                a,
+                b
+            );
+            // Two 32-bit words were produced
+            assert_eq!(sp0, rt.state.sp + 2 * UNIT);
+        }
+
+        // Basic and edge cases
+        check(0, 0);                            // 0 + 0 -> (hi=0, lo=0)
+        check(u32::MAX, 0);                     // max + 0
+        check(u32::MAX, 1);                     // carry into HI -> (hi=1, lo=0)
+        check(u32::MAX, u32::MAX);              // 0xFFFF_FFFF + 0xFFFF_FFFF -> (hi=1, lo=0xFFFF_FFFE)
+        check(0x7FFF_FFFF, 1);                  // boundary without HI carry -> (hi=0, lo=0x8000_0000)
+
+        // Cross terms around the carry boundary
+        check(0xFFFF_0000, 0x0000_FFFF);        // no HI carry -> (hi=0, lo=0xFFFF_FFFF)
+        check(0xFFFF_0001, 0x0000_FFFF);        // exact 2^32 -> (hi=1, lo=0)
+
+        // Symmetry / commutativity sanity
+        check(0x1234_5678, 0x9ABC_DEF0);
+        check(0x9ABC_DEF0, 0x1234_5678);
+    }
+    #[test]
+    fn test_i32mul64() {
+        fn check(a: u32, b: u32) {
+            let sp0 = SP_START;
+            let program = Program::from_instrs(vec![
+                Opcode::I32Const(a.into()),
+                Opcode::I32Const(b.into()),
+                Opcode::I32Mul64,
+            ]);
+            let mut rt = Executor::new(program, SP1CoreOpts::default());
+            rt.run().unwrap();
+
+            let prod = (a as u64).wrapping_mul(b as u64);
+            let lo = (prod & 0xFFFF_FFFF) as u32;
+            let hi = (prod >> 32) as u32;
+
+            // After 64-bit ops, convention is: top-of-stack = HI, next = LO (see test_i32add64).
+            assert_eq!(
+                rt.state.memory.get(rt.state.sp).unwrap().value,
+                hi,
+                "HI mismatch for a={:#x}, b={:#x}",
+                a,
+                b
+            );
+            assert_eq!(
+                rt.state.memory.get(rt.state.sp + 4).unwrap().value,
+                lo,
+                "LO mismatch for a={:#x}, b={:#x}",
+                a,
+                b
+            );
+            // Two 32-bit words remain on the stack
+            assert_eq!(sp0, rt.state.sp + 2 * UNIT);
+        }
+
+        // Edge & sanity cases
+        check(0, 0);                          // zero * zero
+        check(u32::MAX, 1);                   // max * 1
+        check(u32::MAX, u32::MAX);            // max * max -> hi = 0xFFFF_FFFE, lo = 1
+        check(0x8000_0000, 2);                // 2^31 * 2 = 2^32 -> hi=1, lo=0
+        check(0xFFFF_0000, 0x0000_FFFF);      // cross terms
+        // Random-ish sanity and commutativity
+        check(0x1234_5678, 0x9ABC_DEF0);
+        check(0x9ABC_DEF0, 0x1234_5678);
     }
 }

--- a/crates/rwasm/executor/src/record.rs
+++ b/crates/rwasm/executor/src/record.rs
@@ -61,8 +61,10 @@ pub struct ExecutionRecord {
     pub const_events: Vec<ConstEvent>,
     /// A trace of the constant events.
     pub call_events: Vec<CallEvent>,
-
-    pub i64_events: Vec<I64AluEvent>,
+    /// A trace of the Mul64 events.
+    pub mul64_events: Vec<I64AluEvent>,
+    /// A trace of the Add64 events.
+    pub add64_events: Vec<I64AluEvent>,
     /// A trace of the constant events.
     pub sys_state_events: Vec<SysStateEvent>,
 
@@ -284,7 +286,7 @@ impl MachineRecord for ExecutionRecord {
         stats.insert("branch_events".to_string(), self.branch_events.len());
         stats.insert("const_events".to_string(), self.const_events.len());
         stats.insert("call_events".to_string(), self.call_events.len());
-        stats.insert("i64_events".to_string(), self.i64_events.len());
+        stats.insert("i64_events".to_string(), self.mul64_events.len());
 
         for (syscall_code, events) in self.precompile_events.iter() {
             stats.insert(format!("syscall {syscall_code:?}"), events.len());

--- a/crates/rwasm/executor/src/record.rs
+++ b/crates/rwasm/executor/src/record.rs
@@ -14,8 +14,8 @@ use serde::{Deserialize, Serialize};
 use crate::{
     events::{
         AluEvent, BranchEvent, ByteLookupEvent, ByteRecord, CallEvent, ConstEvent, CpuEvent,
-        GlobalInteractionEvent, MemInstrEvent, MemoryInitializeFinalizeEvent, MemoryLocalEvent,
-        PrecompileEvent, PrecompileEvents, SysStateEvent, SyscallEvent,
+        GlobalInteractionEvent, I64AluEvent, MemInstrEvent, MemoryInitializeFinalizeEvent,
+        MemoryLocalEvent, PrecompileEvent, PrecompileEvents, SysStateEvent, SyscallEvent,
     },
     program::Program,
     syscalls::SyscallCode,
@@ -59,6 +59,8 @@ pub struct ExecutionRecord {
     pub const_events: Vec<ConstEvent>,
     /// A trace of the constant events.
     pub call_events: Vec<CallEvent>,
+
+    pub i64_events: Vec<I64AluEvent>,
     /// A trace of the constant events.
     pub sys_state_events: Vec<SysStateEvent>,
 
@@ -279,6 +281,7 @@ impl MachineRecord for ExecutionRecord {
         stats.insert("branch_events".to_string(), self.branch_events.len());
         stats.insert("const_events".to_string(), self.const_events.len());
         stats.insert("call_events".to_string(), self.call_events.len());
+        stats.insert("i64_events".to_string(), self.i64_events.len());
 
         for (syscall_code, events) in self.precompile_events.iter() {
             stats.insert(format!("syscall {syscall_code:?}"), events.len());

--- a/crates/rwasm/machine/Cargo.toml
+++ b/crates/rwasm/machine/Cargo.toml
@@ -65,7 +65,7 @@ p3-poseidon2 = { workspace = true }
 
 #rwasm
 
-rwasm = { git = "https://github.com/fluentlabs-xyz/rwasm.git", branch = "feat/tracing", features = [
+rwasm = { git = "https://github.com/fluentlabs-xyz/rwasm.git", branch = "feat/tracing-i64", features = [
     "std",
     "tracing",
 ] }

--- a/crates/rwasm/machine/Cargo.toml
+++ b/crates/rwasm/machine/Cargo.toml
@@ -65,7 +65,7 @@ p3-poseidon2 = { workspace = true }
 
 #rwasm
 
-rwasm = { git = "https://github.com/fluentlabs-xyz/rwasm.git", branch = "feat/tracing-i64", features = [
+rwasm = { git = "https://github.com/fluentlabs-xyz/rwasm.git", branch = "feat/tracing", features = [
     "std",
     "tracing",
 ] }

--- a/crates/rwasm/machine/src/alu/mod.rs
+++ b/crates/rwasm/machine/src/alu/mod.rs
@@ -3,15 +3,18 @@ pub mod bitwise;
 pub mod divrem;
 pub mod lt;
 pub mod mul;
+pub mod mul64;
 pub mod rotate;
 pub mod sll;
 pub mod sr;
 pub mod trailing;
+
 pub use add_sub::*;
 pub use bitwise::*;
 pub use divrem::*;
 pub use lt::*;
 pub use mul::*;
+pub use mul64::*;
 pub use rotate::*;
 pub use sll::*;
 pub use sr::*;

--- a/crates/rwasm/machine/src/alu/mul/mod.rs
+++ b/crates/rwasm/machine/src/alu/mul/mod.rs
@@ -28,7 +28,7 @@
 //! if lower_half:
 //!     assert_eq(a, m\[0..4\])
 
-mod utils;
+pub(crate) mod utils;
 
 use core::{
     borrow::{Borrow, BorrowMut},
@@ -103,7 +103,7 @@ pub struct MulCols<T> {
     /// The sign extension of `c`.
     pub c_sign_extend: T,
 
-    /// Flag indicating whether the opcode is `MUL` (`u32 x u32`).
+    /// Flag indicating whether the opcode is `MUL`  (`u32 x u32`).
     pub is_mul: T,
 
     /// Flag indicating whether the opcode is `MULH` (`i32 x i32`, upper half).

--- a/crates/rwasm/machine/src/alu/mul64/mod.rs
+++ b/crates/rwasm/machine/src/alu/mul64/mod.rs
@@ -72,7 +72,7 @@ impl<F: PrimeField32> MachineAir<F> for Mul64Chip {
         let events: Vec<_> =
             input.i64_events.iter().filter(|e| e.opcode == Opcode::I32Mul64).collect();
 
-        let nb_rows = input.mul_events.len();
+        let nb_rows = events.len();
         let size_log2 = input.fixed_log2_rows::<F, _>(self);
         let padded_nb_rows = next_power_of_two(nb_rows, size_log2);
 

--- a/crates/rwasm/machine/src/alu/mul64/mod.rs
+++ b/crates/rwasm/machine/src/alu/mul64/mod.rs
@@ -4,7 +4,7 @@ use core::{
 };
 
 use hashbrown::HashMap;
-use p3_air::{Air, AirBuilder, BaseAir};
+use p3_air::{Air, BaseAir};
 use p3_field::{AbstractField, PrimeField, PrimeField32};
 use p3_matrix::{dense::RowMajorMatrix, Matrix};
 use p3_maybe_rayon::prelude::{ParallelBridge, ParallelIterator, ParallelSlice};
@@ -36,7 +36,6 @@ pub struct Mul64Cols<T> {
     pub b: Word<T>,
     pub c: Word<T>,
     pub carry: [T; LONG_WORD_SIZE],
-    pub product: [T; LONG_WORD_SIZE],
     pub is_real: T,
 }
 
@@ -155,19 +154,22 @@ impl Mul64Chip {
             cols.carry[i] = F::from_canonical_u32(carry[i]);
         }
 
-        cols.product = product.map(F::from_canonical_u32);
         cols.a_lo = event.a_lo.into();
         cols.a_hi = event.a_hi.into();
         cols.b = Word(b_word.map(F::from_canonical_u8));
         cols.c = Word(c_word.map(F::from_canonical_u8));
         cols.is_real = F::one();
 
-        // Send range checks for the original 4 bytes
+        let a_lo_word = event.a_lo.to_le_bytes();
+        let a_hi_word = event.a_hi.to_le_bytes();
+
+        // Send range checks for all 32-bit words (inputs and outputs).
         blu.add_u8_range_checks(&b_word);
         blu.add_u8_range_checks(&c_word);
+        blu.add_u8_range_checks(&a_lo_word);
+        blu.add_u8_range_checks(&a_hi_word);
 
         blu.add_u16_range_checks(&carry.map(|x| x as u16));
-        blu.add_u8_range_checks(&product.map(|x| x as u8));
     }
 }
 
@@ -215,25 +217,26 @@ where
             }
         }
 
-        // Carry propagation
+        // Carry propagation, directly constraining against a_lo/a_hi bytes.
         for i in 0..LONG_WORD_SIZE {
             let mut v = m[i].clone();
             if i > 0 {
                 v += local.carry[i - 1].into();
             }
             v -= local.carry[i] * base;
-            builder.assert_eq(local.product[i], v);
-        }
 
-        // Check result against a_lo and a_hi
-        for i in 0..WORD_SIZE {
-            builder.when(local.is_real).assert_eq(local.product[i], local.a_lo[i]);
-            builder.when(local.is_real).assert_eq(local.product[i + WORD_SIZE], local.a_hi[i]);
+            // Select the corresponding output byte from (a_lo, a_hi).
+            let out_byte: AB::Expr =
+                if i < WORD_SIZE { local.a_lo[i].into() } else { local.a_hi[i - WORD_SIZE].into() };
+
+            // Enforce that the carried product byte equals the output byte.
+            builder.assert_eq(out_byte, v);
         }
 
         // Range checks
         builder.slice_range_check_u16(&local.carry, local.is_real);
-        builder.slice_range_check_u8(&local.product, local.is_real);
+        builder.slice_range_check_u8(&local.a_lo.0, local.is_real);
+        builder.slice_range_check_u8(&local.a_hi.0, local.is_real);
 
         let opcode = local.is_real * AB::F::from_canonical_u32(I32Mul64.code());
 

--- a/crates/rwasm/machine/src/alu/mul64/mod.rs
+++ b/crates/rwasm/machine/src/alu/mul64/mod.rs
@@ -8,10 +8,10 @@ use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::{AbstractField, PrimeField, PrimeField32};
 use p3_matrix::{dense::RowMajorMatrix, Matrix};
 use p3_maybe_rayon::prelude::{ParallelBridge, ParallelIterator, ParallelSlice};
-use rwasm::Opcode;
+use rwasm::{Opcode, Opcode::I32Mul64};
 use rwasm_executor::{
     events::{ByteLookupEvent, ByteRecord, I64AluEvent},
-    ByteOpcode, ExecutionRecord,
+    ByteOpcode, ExecutionRecord, DEFAULT_PC_INC,
 };
 use sp1_derive::AlignedBorrow;
 use sp1_primitives::consts::{BYTE_SIZE, LONG_WORD_SIZE, WORD_SIZE};
@@ -72,11 +72,9 @@ impl<F: PrimeField32> MachineAir<F> for Mul64Chip {
         let events: Vec<_> =
             input.i64_events.iter().filter(|e| e.opcode == Opcode::I32Mul64).collect();
 
-        let nb_rows = events.len();
-        let mut padded_nb_rows = next_power_of_two(nb_rows, input.fixed_log2_rows::<F, _>(self));
-        if padded_nb_rows < 16 {
-            padded_nb_rows = 16;
-        }
+        let nb_rows = input.mul_events.len();
+        let size_log2 = input.fixed_log2_rows::<F, _>(self);
+        let padded_nb_rows = next_power_of_two(nb_rows, size_log2);
 
         let mut values = zeroed_f_vec(padded_nb_rows * NUM_MUL64_COLS);
         let chunk_size = std::cmp::max((nb_rows + 1) / num_cpus::get(), 1);
@@ -156,11 +154,15 @@ impl Mul64Chip {
         if b_msb == 1 {
             cols.b_sign_extend = F::one();
             b.resize(LONG_WORD_SIZE, BYTE_MASK);
+        } else {
+            b.resize(LONG_WORD_SIZE, 0);
         }
 
         if c_msb == 1 {
             cols.c_sign_extend = F::one();
             c.resize(LONG_WORD_SIZE, BYTE_MASK);
+        } else {
+            c.resize(LONG_WORD_SIZE, 0);
         }
 
         blu.add_byte_lookup_events(vec![
@@ -296,6 +298,23 @@ where
         // Range checks
         builder.slice_range_check_u16(&local.carry, local.is_real);
         builder.slice_range_check_u8(&local.product, local.is_real);
+
+        builder.receive_64_instruction(
+            AB::Expr::zero(),
+            AB::Expr::zero(),
+            local.pc,
+            local.pc + AB::Expr::from_canonical_u32(DEFAULT_PC_INC),
+            AB::Expr::zero(),
+            AB::F::from_canonical_u32(I32Mul64.code()),
+            local.a_lo, // <-- Added this line
+            local.a_hi,
+            local.b,
+            local.c,
+            AB::Expr::zero(),
+            AB::Expr::zero(),
+            AB::Expr::zero(),
+            local.is_real,
+        );
     }
 }
 

--- a/crates/rwasm/machine/src/alu/mul64/mod.rs
+++ b/crates/rwasm/machine/src/alu/mul64/mod.rs
@@ -4,7 +4,7 @@ use core::{
 };
 
 use hashbrown::HashMap;
-use p3_air::{Air, BaseAir};
+use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::{AbstractField, PrimeField, PrimeField32};
 use p3_matrix::{dense::RowMajorMatrix, Matrix};
 use p3_maybe_rayon::prelude::{ParallelBridge, ParallelIterator, ParallelSlice};
@@ -125,20 +125,23 @@ impl Mul64Chip {
     ) {
         cols.pc = F::from_canonical_u32(event.pc);
 
+        // Inputs are u32 (4 bytes)
         let b_word = event.b.to_le_bytes();
         let c_word = event.c.to_le_bytes();
 
+        // Max sum at any index is small enough for standard logic.
         let mut product = [0u32; LONG_WORD_SIZE];
-        for i in 0..b_word.len() {
-            for j in 0..c_word.len() {
-                if i + j < LONG_WORD_SIZE {
-                    product[i + j] += (b_word[i] as u32) * (c_word[j] as u32);
-                }
+        for i in 0..WORD_SIZE {
+            for j in 0..WORD_SIZE {
+                // i + j will range from 0 to 6 (fits in LONG_WORD_SIZE=8)
+                product[i + j] += (b_word[i] as u32) * (c_word[j] as u32);
             }
         }
 
         let base = (1 << BYTE_SIZE) as u32;
         let mut carry = [0u32; LONG_WORD_SIZE];
+
+        // Standard carry propagation over 8 bytes to form u64 result
         for i in 0..LONG_WORD_SIZE {
             carry[i] = product[i] / base;
             product[i] %= base;
@@ -157,7 +160,7 @@ impl Mul64Chip {
         let a_lo_word = event.a_lo.to_le_bytes();
         let a_hi_word = event.a_hi.to_le_bytes();
 
-        // Send range checks for all 32-bit words (inputs and outputs).
+        // Send range checks for inputs (u8) and carries (u16).
         blu.add_u8_range_checks(&b_word);
         blu.add_u8_range_checks(&c_word);
         blu.add_u8_range_checks(&a_lo_word);
@@ -175,56 +178,46 @@ where
         let main = builder.main();
         let local = main.row_slice(0);
         let local: &Mul64Cols<AB::Var> = (*local).borrow();
-        let base = AB::F::from_canonical_u32(1 << 8);
+        let base = AB::F::from_canonical_u32(1 << BYTE_SIZE);
         let zero = AB::Expr::zero();
 
         builder.assert_bool(local.is_real);
 
-        // Zero-extend b and c from 32 bits to 64 bits (unsigned semantics).
-        let (b, c) = {
-            let mut b = vec![zero.clone(); LONG_WORD_SIZE];
-            let mut c = vec![zero.clone(); LONG_WORD_SIZE];
-            for i in 0..WORD_SIZE {
-                b[i] = local.b[i].into();
-                c[i] = local.c[i].into();
-            }
-            (b, c)
-        };
-
-        // Send range checks for original b and c bytes
+        // Range checks
         builder.slice_range_check_u8(&local.b.0, local.is_real);
         builder.slice_range_check_u8(&local.c.0, local.is_real);
+        builder.slice_range_check_u8(&local.a_lo.0, local.is_real);
+        builder.slice_range_check_u8(&local.a_hi.0, local.is_real);
+        builder.slice_range_check_u16(&local.carry, local.is_real);
 
-        // Uncarried product
+        // We do NOT need to zero-extend b and c to length 8,
+        // we just iterate up to WORD_SIZE (4).
         let mut m: Vec<AB::Expr> = vec![zero.clone(); LONG_WORD_SIZE];
-        for i in 0..LONG_WORD_SIZE {
-            for j in 0..LONG_WORD_SIZE {
-                if i + j < LONG_WORD_SIZE {
-                    m[i + j] = m[i + j].clone() + b[i].clone() * c[j].clone();
-                }
+
+        for i in 0..WORD_SIZE {
+            for j in 0..WORD_SIZE {
+                // No `if i+j < ...` check needed, max index is 6, fits in 8.
+                m[i + j] = m[i + j].clone() + local.b[i].into() * local.c[j].into();
             }
         }
 
-        // Carry propagation, directly constraining against a_lo/a_hi bytes.
-        for i in 0..LONG_WORD_SIZE {
-            let mut v = m[i].clone();
-            if i > 0 {
-                v += local.carry[i - 1].into();
-            }
-            v -= local.carry[i] * base;
+        // Carry propagation logic (must cover full 64-bit result width)
+        let mut prev_carry = zero.clone();
 
-            // Select the corresponding output byte from (a_lo, a_hi).
+        for i in 0..LONG_WORD_SIZE {
+            // Current position sum = computed_products + carry_from_prev
+            let lhs = m[i].clone() + prev_carry.clone();
+
+            // Expected result = output_byte + 256 * new_carry
             let out_byte: AB::Expr =
                 if i < WORD_SIZE { local.a_lo[i].into() } else { local.a_hi[i - WORD_SIZE].into() };
 
-            // Enforce that the carried product byte equals the output byte.
-            builder.assert_eq(out_byte, v);
-        }
+            let rhs = out_byte + local.carry[i] * base;
 
-        // Range checks
-        builder.slice_range_check_u16(&local.carry, local.is_real);
-        builder.slice_range_check_u8(&local.a_lo.0, local.is_real);
-        builder.slice_range_check_u8(&local.a_hi.0, local.is_real);
+            builder.when(local.is_real).assert_eq(lhs, rhs);
+
+            prev_carry = local.carry[i].into();
+        }
 
         let opcode = local.is_real * AB::F::from_canonical_u32(I32Mul64.code());
 
@@ -268,7 +261,7 @@ mod tests {
         let mut output = ExecutionRecord::default();
         let b = 2u32;
         let c = 3u32;
-        let result = (b as i64).wrapping_mul(c as i64);
+        let result = (b as i64).wrapping_mul(c as i64); // effectively u32*u32 -> u64
         shard.mul64_events.push(I64AluEvent {
             pc: 0,
             opcode: Opcode::I32Mul64,
@@ -282,7 +275,7 @@ mod tests {
         });
         let chip = Mul64Chip::default();
         let trace: RowMajorMatrix<BabyBear> = chip.generate_trace(&shard, &mut output);
-        assert_eq!(trace.height(), 16); // Padded to a minimum of 16
+        assert_eq!(trace.height(), 16);
     }
 
     #[test]
@@ -299,7 +292,7 @@ mod tests {
             (1, 1),
             (u32::MAX, 1),
             (2, 3),
-            (u32::MAX, u32::MAX),
+            (u32::MAX, u32::MAX), // Max value check
             (1 << 20, 1 << 20),
         ];
 

--- a/crates/rwasm/machine/src/alu/mul64/mod.rs
+++ b/crates/rwasm/machine/src/alu/mul64/mod.rs
@@ -8,10 +8,10 @@ use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::{AbstractField, PrimeField, PrimeField32};
 use p3_matrix::{dense::RowMajorMatrix, Matrix};
 use p3_maybe_rayon::prelude::{ParallelBridge, ParallelIterator, ParallelSlice};
-use rwasm::{Opcode, Opcode::I32Mul64};
+use rwasm::Opcode::I32Mul64;
 use rwasm_executor::{
     events::{ByteLookupEvent, ByteRecord, I64AluEvent},
-    ByteOpcode, ExecutionRecord, DEFAULT_PC_INC,
+    ExecutionRecord, DEFAULT_PC_INC,
 };
 use sp1_derive::AlignedBorrow;
 use sp1_primitives::consts::{BYTE_SIZE, LONG_WORD_SIZE, WORD_SIZE};
@@ -23,11 +23,6 @@ use crate::{
 };
 
 pub const NUM_MUL64_COLS: usize = size_of::<Mul64Cols<u8>>();
-const BYTE_MASK: u8 = 0xff;
-
-pub const fn get_msb(a: [u8; WORD_SIZE]) -> u8 {
-    (a[WORD_SIZE - 1] >> (BYTE_SIZE - 1)) & 1
-}
 
 #[derive(Default)]
 pub struct Mul64Chip;
@@ -42,8 +37,6 @@ pub struct Mul64Cols<T> {
     pub c: Word<T>,
     pub carry: [T; LONG_WORD_SIZE],
     pub product: [T; LONG_WORD_SIZE],
-    pub b_msb: T,
-    pub c_msb: T,
     pub is_real: T,
 }
 
@@ -66,10 +59,7 @@ impl<F: PrimeField32> MachineAir<F> for Mul64Chip {
         input: &ExecutionRecord,
         _: &mut ExecutionRecord,
     ) -> RowMajorMatrix<F> {
-        let events: Vec<_> =
-            input.i64_events.iter().filter(|e| e.opcode == Opcode::I32Mul64).collect();
-
-        let nb_rows = events.len();
+        let nb_rows = input.mul64_events.len();
         let size_log2 = input.fixed_log2_rows::<F, _>(self);
         let padded_nb_rows = next_power_of_two(nb_rows, size_log2);
 
@@ -84,7 +74,7 @@ impl<F: PrimeField32> MachineAir<F> for Mul64Chip {
 
                     if idx < nb_rows {
                         let mut byte_lookup_events = Vec::new();
-                        let event = events[idx];
+                        let event = &input.mul64_events[idx];
                         self.event_to_row(event, cols, &mut byte_lookup_events);
                     }
                 });
@@ -95,12 +85,10 @@ impl<F: PrimeField32> MachineAir<F> for Mul64Chip {
     }
 
     fn generate_dependencies(&self, input: &Self::Record, output: &mut Self::Record) {
-        let events: Vec<_> =
-            input.i64_events.iter().filter(|e| e.opcode == Opcode::I32Mul64).collect();
+        let chunk_size = std::cmp::max(input.mul64_events.len() / num_cpus::get(), 1);
 
-        let chunk_size = std::cmp::max(events.len() / num_cpus::get(), 1);
-
-        let blu_batches = events
+        let blu_batches = input
+            .mul64_events
             .par_chunks(chunk_size)
             .map(|events| {
                 let mut blu: HashMap<ByteLookupEvent, usize> = HashMap::new();
@@ -117,7 +105,11 @@ impl<F: PrimeField32> MachineAir<F> for Mul64Chip {
     }
 
     fn included(&self, shard: &Self::Record) -> bool {
-        shard.i64_events.iter().any(|e| e.opcode == Opcode::I32Mul64)
+        if let Some(shape) = shard.shape.as_ref() {
+            shape.included::<F, _>(self)
+        } else {
+            !shard.mul64_events.is_empty()
+        }
     }
 
     fn local_only(&self) -> bool {
@@ -139,32 +131,9 @@ impl Mul64Chip {
 
         let mut b = b_word.to_vec();
         let mut c = c_word.to_vec();
-
-        // Handle signs. I32Mul64 is signed.
-        let b_msb = get_msb(b_word);
-        cols.b_msb = F::from_canonical_u8(b_msb);
-        let c_msb = get_msb(c_word);
-        cols.c_msb = F::from_canonical_u8(c_msb);
-
-        b.resize(LONG_WORD_SIZE, BYTE_MASK * b_msb);
-        c.resize(LONG_WORD_SIZE, BYTE_MASK * c_msb);
-
-        blu.add_byte_lookup_events(vec![
-            ByteLookupEvent {
-                opcode: ByteOpcode::MSB,
-                a1: b_msb as u16,
-                a2: 0,
-                b: b_word[WORD_SIZE - 1],
-                c: 0,
-            },
-            ByteLookupEvent {
-                opcode: ByteOpcode::MSB,
-                a1: c_msb as u16,
-                a2: 0,
-                b: c_word[WORD_SIZE - 1],
-                c: 0,
-            },
-        ]);
+        // For I32Mul64 we now interpret b and c as u32 and zero-extend them to 64 bits.
+        b.resize(LONG_WORD_SIZE, 0);
+        c.resize(LONG_WORD_SIZE, 0);
 
         let mut product = [0u32; LONG_WORD_SIZE];
         for i in 0..b.len() {
@@ -197,24 +166,6 @@ impl Mul64Chip {
         blu.add_u8_range_checks(&b_word);
         blu.add_u8_range_checks(&c_word);
 
-        // Send range checks for the extended upper 4 bytes
-        for i in WORD_SIZE..LONG_WORD_SIZE {
-            blu.add_byte_lookup_event(ByteLookupEvent {
-                opcode: ByteOpcode::U8Range,
-                a1: 0,
-                a2: 0,
-                b: b[i],
-                c: 0,
-            });
-            blu.add_byte_lookup_event(ByteLookupEvent {
-                opcode: ByteOpcode::U8Range,
-                a1: 0,
-                a2: 0,
-                b: c[i],
-                c: 0,
-            });
-        }
-
         blu.add_u16_range_checks(&carry.map(|x| x as u16));
         blu.add_u8_range_checks(&product.map(|x| x as u8));
     }
@@ -230,29 +181,10 @@ where
         let local: &Mul64Cols<AB::Var> = (*local).borrow();
         let base = AB::F::from_canonical_u32(1 << 8);
         let zero: AB::Expr = AB::F::zero().into();
-        let byte_mask = AB::F::from_canonical_u8(BYTE_MASK);
 
         builder.assert_bool(local.is_real);
 
-        // MSB checks
-        builder.send_byte(
-            ByteOpcode::MSB.as_field::<AB::F>(),
-            local.b_msb,
-            local.b[WORD_SIZE - 1],
-            zero.clone(),
-            local.is_real,
-        );
-        builder.send_byte(
-            ByteOpcode::MSB.as_field::<AB::F>(),
-            local.c_msb,
-            local.c[WORD_SIZE - 1],
-            zero.clone(),
-            local.is_real,
-        );
-        builder.assert_bool(local.b_msb);
-        builder.assert_bool(local.c_msb);
-
-        // Sign extend b and c
+        // Zero-extend b and c from 32 bits to 64 bits (unsigned semantics).
         let (b, c) = {
             let mut b: Vec<AB::Expr> = vec![zero.clone(); LONG_WORD_SIZE];
             let mut c: Vec<AB::Expr> = vec![zero.clone(); LONG_WORD_SIZE];
@@ -261,8 +193,9 @@ where
                     b[i] = local.b[i].into();
                     c[i] = local.c[i].into();
                 } else {
-                    b[i] = local.b_msb * byte_mask;
-                    c[i] = local.c_msb * byte_mask;
+                    // Upper bytes are zero for u32 operands.
+                    b[i] = zero.clone();
+                    c[i] = zero.clone();
                 }
             }
             (b, c)
@@ -271,24 +204,6 @@ where
         // Send range checks for original b and c bytes
         builder.slice_range_check_u8(&local.b.0, local.is_real);
         builder.slice_range_check_u8(&local.c.0, local.is_real);
-
-        // Send range checks ONLY for the sign-extended upper 4 bytes
-        for i in WORD_SIZE..LONG_WORD_SIZE {
-            builder.send_byte(
-                ByteOpcode::U8Range.as_field::<AB::F>(),
-                AB::Expr::zero(),
-                b[i].clone(),
-                AB::Expr::zero(),
-                local.is_real,
-            );
-            builder.send_byte(
-                ByteOpcode::U8Range.as_field::<AB::F>(),
-                AB::Expr::zero(),
-                c[i].clone(),
-                AB::Expr::zero(),
-                local.is_real,
-            );
-        }
 
         // Uncarried product
         let mut m: Vec<AB::Expr> = vec![zero.clone(); LONG_WORD_SIZE];
@@ -362,8 +277,8 @@ mod tests {
         let mut output = ExecutionRecord::default();
         let b = 2u32;
         let c = 3u32;
-        let result = (b as i32 as i64) * (c as i32 as i64);
-        shard.i64_events.push(I64AluEvent {
+        let result = (b as i64).wrapping_mul(c as i64);
+        shard.mul64_events.push(I64AluEvent {
             pc: 0,
             opcode: Opcode::I32Mul64,
             a_lo: result as u32,
@@ -398,8 +313,8 @@ mod tests {
         ];
 
         for (b, c) in test_cases {
-            let result = (b as i32 as i64) * (c as i32 as i64);
-            shard.i64_events.push(I64AluEvent {
+            let result = (b as i64).wrapping_mul(c as i64);
+            shard.mul64_events.push(I64AluEvent {
                 pc: 0,
                 opcode: Opcode::I32Mul64,
                 a_lo: result as u32,
@@ -426,7 +341,7 @@ mod tests {
 
         let b = 12345u32;
         let c = 54321u32;
-        let correct_res = (b as i32 as i64) * (c as i32 as i64);
+        let correct_res = (b as i64).wrapping_mul(c as i64);
         let wrong_res = correct_res.wrapping_add(1);
 
         let program = rwasm_executor::Program::from_instrs(vec![
@@ -441,7 +356,7 @@ mod tests {
         let malicious = move |prover: &P, record: &mut ExecutionRecord| {
             let mut malicious_record = record.clone();
             if let Some(event) =
-                malicious_record.i64_events.iter_mut().find(|e| e.opcode == Opcode::I32Mul64)
+                malicious_record.mul64_events.iter_mut().find(|e| e.opcode == Opcode::I32Mul64)
             {
                 event.a_lo = wrong_res as u32;
                 event.a_hi = (wrong_res >> 32) as u32;

--- a/crates/rwasm/machine/src/alu/mul64/mod.rs
+++ b/crates/rwasm/machine/src/alu/mul64/mod.rs
@@ -137,7 +137,7 @@ impl Mul64Chip {
     ) {
         cols.pc = F::from_canonical_u32(event.pc);
 
-        let a_lo_word = event.a.to_le_bytes();
+        let a_lo_word = event.a_lo.to_le_bytes();
         let a_hi_word = event.a_hi.to_le_bytes();
         let b_word = event.b.to_le_bytes();
         let c_word = event.c.to_le_bytes();
@@ -299,14 +299,16 @@ where
         builder.slice_range_check_u16(&local.carry, local.is_real);
         builder.slice_range_check_u8(&local.product, local.is_real);
 
+        let opcode = local.is_mul64 * AB::F::from_canonical_u32(I32Mul64.code());
+
         builder.receive_64_instruction(
             AB::Expr::zero(),
             AB::Expr::zero(),
             local.pc,
             local.pc + AB::Expr::from_canonical_u32(DEFAULT_PC_INC),
             AB::Expr::zero(),
-            AB::F::from_canonical_u32(I32Mul64.code()),
-            local.a_lo, // <-- Added this line
+            opcode,
+            local.a_lo,
             local.a_hi,
             local.b,
             local.c,
@@ -343,7 +345,7 @@ mod tests {
         shard.i64_events.push(I64AluEvent {
             pc: 0,
             opcode: Opcode::I32Mul64,
-            a: result as u32,
+            a_lo: result as u32,
             a_hi: (result >> 32) as u32,
             b,
             c,
@@ -379,7 +381,7 @@ mod tests {
             shard.i64_events.push(I64AluEvent {
                 pc: 0,
                 opcode: Opcode::I32Mul64,
-                a: result as u32,
+                a_lo: result as u32,
                 a_hi: (result >> 32) as u32,
                 b,
                 c,
@@ -420,7 +422,7 @@ mod tests {
             if let Some(event) =
                 malicious_record.i64_events.iter_mut().find(|e| e.opcode == Opcode::I32Mul64)
             {
-                event.a = wrong_res as u32;
+                event.a_lo = wrong_res as u32;
                 event.a_hi = (wrong_res >> 32) as u32;
             }
             prover.generate_traces(&malicious_record)

--- a/crates/rwasm/machine/src/alu/mul64/mod.rs
+++ b/crates/rwasm/machine/src/alu/mul64/mod.rs
@@ -29,7 +29,6 @@ pub const fn get_msb(a: [u8; WORD_SIZE]) -> u8 {
     (a[WORD_SIZE - 1] >> (BYTE_SIZE - 1)) & 1
 }
 
-
 #[derive(Default)]
 pub struct Mul64Chip;
 
@@ -70,11 +69,8 @@ impl<F: PrimeField32> MachineAir<F> for Mul64Chip {
         input: &ExecutionRecord,
         _: &mut ExecutionRecord,
     ) -> RowMajorMatrix<F> {
-        let events: Vec<_> = input
-            .i64_events
-            .iter()
-            .filter(|e| e.opcode == Opcode::I32Mul64)
-            .collect();
+        let events: Vec<_> =
+            input.i64_events.iter().filter(|e| e.opcode == Opcode::I32Mul64).collect();
 
         let nb_rows = events.len();
         let mut padded_nb_rows = next_power_of_two(nb_rows, input.fixed_log2_rows::<F, _>(self));
@@ -85,34 +81,27 @@ impl<F: PrimeField32> MachineAir<F> for Mul64Chip {
         let mut values = zeroed_f_vec(padded_nb_rows * NUM_MUL64_COLS);
         let chunk_size = std::cmp::max((nb_rows + 1) / num_cpus::get(), 1);
 
-        values
-            .chunks_mut(chunk_size * NUM_MUL64_COLS)
-            .enumerate()
-            .par_bridge()
-            .for_each(|(i, rows)| {
-                rows.chunks_mut(NUM_MUL64_COLS)
-                    .enumerate()
-                    .for_each(|(j, row)| {
-                        let idx = i * chunk_size + j;
-                        let cols: &mut Mul64Cols<F> = row.borrow_mut();
+        values.chunks_mut(chunk_size * NUM_MUL64_COLS).enumerate().par_bridge().for_each(
+            |(i, rows)| {
+                rows.chunks_mut(NUM_MUL64_COLS).enumerate().for_each(|(j, row)| {
+                    let idx = i * chunk_size + j;
+                    let cols: &mut Mul64Cols<F> = row.borrow_mut();
 
-                        if idx < nb_rows {
-                            let mut byte_lookup_events = Vec::new();
-                            let event = events[idx];
-                            self.event_to_row(event, cols, &mut byte_lookup_events);
-                        }
-                    });
-            });
+                    if idx < nb_rows {
+                        let mut byte_lookup_events = Vec::new();
+                        let event = events[idx];
+                        self.event_to_row(event, cols, &mut byte_lookup_events);
+                    }
+                });
+            },
+        );
 
         RowMajorMatrix::new(values, NUM_MUL64_COLS)
     }
 
     fn generate_dependencies(&self, input: &Self::Record, output: &mut Self::Record) {
-        let events: Vec<_> = input
-            .i64_events
-            .iter()
-            .filter(|e| e.opcode == Opcode::I32Mul64)
-            .collect();
+        let events: Vec<_> =
+            input.i64_events.iter().filter(|e| e.opcode == Opcode::I32Mul64).collect();
 
         let chunk_size = std::cmp::max(events.len() / num_cpus::get(), 1);
 
@@ -133,10 +122,7 @@ impl<F: PrimeField32> MachineAir<F> for Mul64Chip {
     }
 
     fn included(&self, shard: &Self::Record) -> bool {
-        shard
-            .i64_events
-            .iter()
-            .any(|e| e.opcode == Opcode::I32Mul64)
+        shard.i64_events.iter().any(|e| e.opcode == Opcode::I32Mul64)
     }
 
     fn local_only(&self) -> bool {
@@ -297,18 +283,14 @@ where
             if i > 0 {
                 v += local.carry[i - 1].into();
             }
-            v -= local.carry[i] * base.clone();
+            v -= local.carry[i] * base;
             builder.assert_eq(local.product[i], v);
         }
 
         // Check result against a_lo and a_hi
         for i in 0..WORD_SIZE {
-            builder
-                .when(local.is_real)
-                .assert_eq(local.product[i], local.a_lo[i]);
-            builder
-                .when(local.is_real)
-                .assert_eq(local.product[i + WORD_SIZE], local.a_hi[i]);
+            builder.when(local.is_real).assert_eq(local.product[i], local.a_lo[i]);
+            builder.when(local.is_real).assert_eq(local.product[i + WORD_SIZE], local.a_hi[i]);
         }
 
         // Range checks
@@ -416,10 +398,8 @@ mod tests {
 
         let malicious = move |prover: &P, record: &mut ExecutionRecord| {
             let mut malicious_record = record.clone();
-            if let Some(event) = malicious_record
-                .i64_events
-                .iter_mut()
-                .find(|e| e.opcode == Opcode::I32Mul64)
+            if let Some(event) =
+                malicious_record.i64_events.iter_mut().find(|e| e.opcode == Opcode::I32Mul64)
             {
                 event.a = wrong_res as u32;
                 event.a_hi = (wrong_res >> 32) as u32;

--- a/crates/rwasm/machine/src/alu/mul64/mod.rs
+++ b/crates/rwasm/machine/src/alu/mul64/mod.rs
@@ -44,9 +44,6 @@ pub struct Mul64Cols<T> {
     pub product: [T; LONG_WORD_SIZE],
     pub b_msb: T,
     pub c_msb: T,
-    pub b_sign_extend: T,
-    pub c_sign_extend: T,
-    pub is_mul64: T,
     pub is_real: T,
 }
 
@@ -137,8 +134,6 @@ impl Mul64Chip {
     ) {
         cols.pc = F::from_canonical_u32(event.pc);
 
-        let a_lo_word = event.a_lo.to_le_bytes();
-        let a_hi_word = event.a_hi.to_le_bytes();
         let b_word = event.b.to_le_bytes();
         let c_word = event.c.to_le_bytes();
 
@@ -151,19 +146,8 @@ impl Mul64Chip {
         let c_msb = get_msb(c_word);
         cols.c_msb = F::from_canonical_u8(c_msb);
 
-        if b_msb == 1 {
-            cols.b_sign_extend = F::one();
-            b.resize(LONG_WORD_SIZE, BYTE_MASK);
-        } else {
-            b.resize(LONG_WORD_SIZE, 0);
-        }
-
-        if c_msb == 1 {
-            cols.c_sign_extend = F::one();
-            c.resize(LONG_WORD_SIZE, BYTE_MASK);
-        } else {
-            c.resize(LONG_WORD_SIZE, 0);
-        }
+        b.resize(LONG_WORD_SIZE, BYTE_MASK * b_msb);
+        c.resize(LONG_WORD_SIZE, BYTE_MASK * c_msb);
 
         blu.add_byte_lookup_events(vec![
             ByteLookupEvent {
@@ -203,12 +187,11 @@ impl Mul64Chip {
         }
 
         cols.product = product.map(F::from_canonical_u32);
-        cols.a_lo = Word(a_lo_word.map(F::from_canonical_u8));
-        cols.a_hi = Word(a_hi_word.map(F::from_canonical_u8));
+        cols.a_lo = event.a_lo.into();
+        cols.a_hi = event.a_hi.into();
         cols.b = Word(b_word.map(F::from_canonical_u8));
         cols.c = Word(c_word.map(F::from_canonical_u8));
         cols.is_real = F::one();
-        cols.is_mul64 = F::one();
 
         // Send range checks for the original 4 bytes
         blu.add_u8_range_checks(&b_word);
@@ -250,8 +233,6 @@ where
         let byte_mask = AB::F::from_canonical_u8(BYTE_MASK);
 
         builder.assert_bool(local.is_real);
-        builder.assert_bool(local.is_mul64);
-        builder.when(local.is_real).assert_one(local.is_mul64);
 
         // MSB checks
         builder.send_byte(
@@ -268,12 +249,8 @@ where
             zero.clone(),
             local.is_real,
         );
-
-        // Sign extension calculation
-        builder.assert_eq(local.b_sign_extend, local.b_msb);
-        builder.assert_eq(local.c_sign_extend, local.c_msb);
-        builder.assert_bool(local.b_sign_extend);
-        builder.assert_bool(local.c_sign_extend);
+        builder.assert_bool(local.b_msb);
+        builder.assert_bool(local.c_msb);
 
         // Sign extend b and c
         let (b, c) = {
@@ -284,8 +261,8 @@ where
                     b[i] = local.b[i].into();
                     c[i] = local.c[i].into();
                 } else {
-                    b[i] = local.b_sign_extend * byte_mask;
-                    c[i] = local.c_sign_extend * byte_mask;
+                    b[i] = local.b_msb * byte_mask;
+                    c[i] = local.c_msb * byte_mask;
                 }
             }
             (b, c)
@@ -343,7 +320,7 @@ where
         builder.slice_range_check_u16(&local.carry, local.is_real);
         builder.slice_range_check_u8(&local.product, local.is_real);
 
-        let opcode = local.is_mul64 * AB::F::from_canonical_u32(I32Mul64.code());
+        let opcode = local.is_real * AB::F::from_canonical_u32(I32Mul64.code());
 
         builder.receive_64_instruction(
             AB::Expr::zero(),

--- a/crates/rwasm/machine/src/alu/mul64/mod.rs
+++ b/crates/rwasm/machine/src/alu/mul64/mod.rs
@@ -128,17 +128,11 @@ impl Mul64Chip {
         let b_word = event.b.to_le_bytes();
         let c_word = event.c.to_le_bytes();
 
-        let mut b = b_word.to_vec();
-        let mut c = c_word.to_vec();
-        // For I32Mul64 we now interpret b and c as u32 and zero-extend them to 64 bits.
-        b.resize(LONG_WORD_SIZE, 0);
-        c.resize(LONG_WORD_SIZE, 0);
-
         let mut product = [0u32; LONG_WORD_SIZE];
-        for i in 0..b.len() {
-            for j in 0..c.len() {
+        for i in 0..b_word.len() {
+            for j in 0..c_word.len() {
                 if i + j < LONG_WORD_SIZE {
-                    product[i + j] += (b[i] as u32) * (c[j] as u32);
+                    product[i + j] += (b_word[i] as u32) * (c_word[j] as u32);
                 }
             }
         }
@@ -156,8 +150,8 @@ impl Mul64Chip {
 
         cols.a_lo = event.a_lo.into();
         cols.a_hi = event.a_hi.into();
-        cols.b = Word(b_word.map(F::from_canonical_u8));
-        cols.c = Word(c_word.map(F::from_canonical_u8));
+        cols.b = event.b.into();
+        cols.c = event.c.into();
         cols.is_real = F::one();
 
         let a_lo_word = event.a_lo.to_le_bytes();
@@ -182,23 +176,17 @@ where
         let local = main.row_slice(0);
         let local: &Mul64Cols<AB::Var> = (*local).borrow();
         let base = AB::F::from_canonical_u32(1 << 8);
-        let zero: AB::Expr = AB::F::zero().into();
+        let zero = AB::Expr::zero();
 
         builder.assert_bool(local.is_real);
 
         // Zero-extend b and c from 32 bits to 64 bits (unsigned semantics).
         let (b, c) = {
-            let mut b: Vec<AB::Expr> = vec![zero.clone(); LONG_WORD_SIZE];
-            let mut c: Vec<AB::Expr> = vec![zero.clone(); LONG_WORD_SIZE];
-            for i in 0..LONG_WORD_SIZE {
-                if i < WORD_SIZE {
-                    b[i] = local.b[i].into();
-                    c[i] = local.c[i].into();
-                } else {
-                    // Upper bytes are zero for u32 operands.
-                    b[i] = zero.clone();
-                    c[i] = zero.clone();
-                }
+            let mut b = vec![zero.clone(); LONG_WORD_SIZE];
+            let mut c = vec![zero.clone(); LONG_WORD_SIZE];
+            for i in 0..WORD_SIZE {
+                b[i] = local.b[i].into();
+                c[i] = local.c[i].into();
             }
             (b, c)
         };

--- a/crates/rwasm/machine/src/alu/mul64/mod.rs
+++ b/crates/rwasm/machine/src/alu/mul64/mod.rs
@@ -1,0 +1,434 @@
+use core::{
+    borrow::{Borrow, BorrowMut},
+    mem::size_of,
+};
+
+use hashbrown::HashMap;
+use p3_air::{Air, AirBuilder, BaseAir};
+use p3_field::{AbstractField, PrimeField, PrimeField32};
+use p3_matrix::{dense::RowMajorMatrix, Matrix};
+use p3_maybe_rayon::prelude::{ParallelBridge, ParallelIterator, ParallelSlice};
+use rwasm::Opcode;
+use rwasm_executor::{
+    events::{ByteLookupEvent, ByteRecord, I64AluEvent},
+    ByteOpcode, ExecutionRecord,
+};
+use sp1_derive::AlignedBorrow;
+use sp1_primitives::consts::{BYTE_SIZE, LONG_WORD_SIZE, WORD_SIZE};
+use sp1_stark::{air::MachineAir, Word};
+
+use crate::{
+    air::SP1CoreAirBuilder,
+    utils::{next_power_of_two, zeroed_f_vec},
+};
+
+pub const NUM_MUL64_COLS: usize = size_of::<Mul64Cols<u8>>();
+const BYTE_MASK: u8 = 0xff;
+
+pub const fn get_msb(a: [u8; WORD_SIZE]) -> u8 {
+    (a[WORD_SIZE - 1] >> (BYTE_SIZE - 1)) & 1
+}
+
+
+#[derive(Default)]
+pub struct Mul64Chip;
+
+#[derive(AlignedBorrow, Default, Debug, Clone, Copy)]
+#[repr(C)]
+pub struct Mul64Cols<T> {
+    pub pc: T,
+    pub a_lo: Word<T>,
+    pub a_hi: Word<T>,
+    pub b: Word<T>,
+    pub c: Word<T>,
+    pub carry: [T; LONG_WORD_SIZE],
+    pub product: [T; LONG_WORD_SIZE],
+    pub b_msb: T,
+    pub c_msb: T,
+    pub b_sign_extend: T,
+    pub c_sign_extend: T,
+    pub is_mul64: T,
+    pub is_real: T,
+}
+
+impl<F> BaseAir<F> for Mul64Chip {
+    fn width(&self) -> usize {
+        NUM_MUL64_COLS
+    }
+}
+
+impl<F: PrimeField32> MachineAir<F> for Mul64Chip {
+    type Record = ExecutionRecord;
+    type Program = rwasm_executor::Program;
+
+    fn name(&self) -> String {
+        "Mul64".to_string()
+    }
+
+    fn generate_trace(
+        &self,
+        input: &ExecutionRecord,
+        _: &mut ExecutionRecord,
+    ) -> RowMajorMatrix<F> {
+        let events: Vec<_> = input
+            .i64_events
+            .iter()
+            .filter(|e| e.opcode == Opcode::I32Mul64)
+            .collect();
+
+        let nb_rows = events.len();
+        let mut padded_nb_rows = next_power_of_two(nb_rows, input.fixed_log2_rows::<F, _>(self));
+        if padded_nb_rows < 16 {
+            padded_nb_rows = 16;
+        }
+
+        let mut values = zeroed_f_vec(padded_nb_rows * NUM_MUL64_COLS);
+        let chunk_size = std::cmp::max((nb_rows + 1) / num_cpus::get(), 1);
+
+        values
+            .chunks_mut(chunk_size * NUM_MUL64_COLS)
+            .enumerate()
+            .par_bridge()
+            .for_each(|(i, rows)| {
+                rows.chunks_mut(NUM_MUL64_COLS)
+                    .enumerate()
+                    .for_each(|(j, row)| {
+                        let idx = i * chunk_size + j;
+                        let cols: &mut Mul64Cols<F> = row.borrow_mut();
+
+                        if idx < nb_rows {
+                            let mut byte_lookup_events = Vec::new();
+                            let event = events[idx];
+                            self.event_to_row(event, cols, &mut byte_lookup_events);
+                        }
+                    });
+            });
+
+        RowMajorMatrix::new(values, NUM_MUL64_COLS)
+    }
+
+    fn generate_dependencies(&self, input: &Self::Record, output: &mut Self::Record) {
+        let events: Vec<_> = input
+            .i64_events
+            .iter()
+            .filter(|e| e.opcode == Opcode::I32Mul64)
+            .collect();
+
+        let chunk_size = std::cmp::max(events.len() / num_cpus::get(), 1);
+
+        let blu_batches = events
+            .par_chunks(chunk_size)
+            .map(|events| {
+                let mut blu: HashMap<ByteLookupEvent, usize> = HashMap::new();
+                events.iter().for_each(|event| {
+                    let mut row = [F::zero(); NUM_MUL64_COLS];
+                    let cols: &mut Mul64Cols<F> = row.as_mut_slice().borrow_mut();
+                    self.event_to_row(event, cols, &mut blu);
+                });
+                blu
+            })
+            .collect::<Vec<_>>();
+
+        output.add_byte_lookup_events_from_maps(blu_batches.iter().collect::<Vec<_>>());
+    }
+
+    fn included(&self, shard: &Self::Record) -> bool {
+        shard
+            .i64_events
+            .iter()
+            .any(|e| e.opcode == Opcode::I32Mul64)
+    }
+
+    fn local_only(&self) -> bool {
+        true
+    }
+}
+
+impl Mul64Chip {
+    fn event_to_row<F: PrimeField>(
+        &self,
+        event: &I64AluEvent,
+        cols: &mut Mul64Cols<F>,
+        blu: &mut impl ByteRecord,
+    ) {
+        cols.pc = F::from_canonical_u32(event.pc);
+
+        let a_lo_word = event.a.to_le_bytes();
+        let a_hi_word = event.a_hi.to_le_bytes();
+        let b_word = event.b.to_le_bytes();
+        let c_word = event.c.to_le_bytes();
+
+        let mut b = b_word.to_vec();
+        let mut c = c_word.to_vec();
+
+        // Handle signs. I32Mul64 is signed.
+        let b_msb = get_msb(b_word);
+        cols.b_msb = F::from_canonical_u8(b_msb);
+        let c_msb = get_msb(c_word);
+        cols.c_msb = F::from_canonical_u8(c_msb);
+
+        if b_msb == 1 {
+            cols.b_sign_extend = F::one();
+            b.resize(LONG_WORD_SIZE, BYTE_MASK);
+        }
+
+        if c_msb == 1 {
+            cols.c_sign_extend = F::one();
+            c.resize(LONG_WORD_SIZE, BYTE_MASK);
+        }
+
+        blu.add_byte_lookup_events(vec![
+            ByteLookupEvent {
+                opcode: ByteOpcode::MSB,
+                a1: b_msb as u16,
+                a2: 0,
+                b: b_word[WORD_SIZE - 1],
+                c: 0,
+            },
+            ByteLookupEvent {
+                opcode: ByteOpcode::MSB,
+                a1: c_msb as u16,
+                a2: 0,
+                b: c_word[WORD_SIZE - 1],
+                c: 0,
+            },
+        ]);
+
+        let mut product = [0u32; LONG_WORD_SIZE];
+        for i in 0..b.len() {
+            for j in 0..c.len() {
+                if i + j < LONG_WORD_SIZE {
+                    product[i + j] += (b[i] as u32) * (c[j] as u32);
+                }
+            }
+        }
+
+        let base = (1 << BYTE_SIZE) as u32;
+        let mut carry = [0u32; LONG_WORD_SIZE];
+        for i in 0..LONG_WORD_SIZE {
+            carry[i] = product[i] / base;
+            product[i] %= base;
+            if i + 1 < LONG_WORD_SIZE {
+                product[i + 1] += carry[i];
+            }
+            cols.carry[i] = F::from_canonical_u32(carry[i]);
+        }
+
+        cols.product = product.map(F::from_canonical_u32);
+        cols.a_lo = Word(a_lo_word.map(F::from_canonical_u8));
+        cols.a_hi = Word(a_hi_word.map(F::from_canonical_u8));
+        cols.b = Word(b_word.map(F::from_canonical_u8));
+        cols.c = Word(c_word.map(F::from_canonical_u8));
+        cols.is_real = F::one();
+        cols.is_mul64 = F::one();
+
+        blu.add_u16_range_checks(&carry.map(|x| x as u16));
+        blu.add_u8_range_checks(&product.map(|x| x as u8));
+    }
+}
+
+impl<AB> Air<AB> for Mul64Chip
+where
+    AB: SP1CoreAirBuilder,
+{
+    fn eval(&self, builder: &mut AB) {
+        let main = builder.main();
+        let local = main.row_slice(0);
+        let local: &Mul64Cols<AB::Var> = (*local).borrow();
+        let base = AB::F::from_canonical_u32(1 << 8);
+        let zero: AB::Expr = AB::F::zero().into();
+        let byte_mask = AB::F::from_canonical_u8(BYTE_MASK);
+
+        builder.assert_bool(local.is_real);
+        builder.assert_bool(local.is_mul64);
+        builder.when(local.is_real).assert_one(local.is_mul64);
+
+        // MSB checks
+        builder.send_byte(
+            ByteOpcode::MSB.as_field::<AB::F>(),
+            local.b_msb,
+            local.b[WORD_SIZE - 1],
+            zero.clone(),
+            local.is_real,
+        );
+        builder.send_byte(
+            ByteOpcode::MSB.as_field::<AB::F>(),
+            local.c_msb,
+            local.c[WORD_SIZE - 1],
+            zero.clone(),
+            local.is_real,
+        );
+
+        // Sign extension calculation
+        builder.assert_eq(local.b_sign_extend, local.b_msb);
+        builder.assert_eq(local.c_sign_extend, local.c_msb);
+        builder.assert_bool(local.b_sign_extend);
+        builder.assert_bool(local.c_sign_extend);
+
+        // Sign extend b and c
+        let (b, c) = {
+            let mut b: Vec<AB::Expr> = vec![zero.clone(); LONG_WORD_SIZE];
+            let mut c: Vec<AB::Expr> = vec![zero.clone(); LONG_WORD_SIZE];
+            for i in 0..LONG_WORD_SIZE {
+                if i < WORD_SIZE {
+                    b[i] = local.b[i].into();
+                    c[i] = local.c[i].into();
+                } else {
+                    b[i] = local.b_sign_extend * byte_mask;
+                    c[i] = local.c_sign_extend * byte_mask;
+                }
+            }
+            (b, c)
+        };
+
+        // Uncarried product
+        let mut m: Vec<AB::Expr> = vec![zero.clone(); LONG_WORD_SIZE];
+        for i in 0..LONG_WORD_SIZE {
+            for j in 0..LONG_WORD_SIZE {
+                if i + j < LONG_WORD_SIZE {
+                    m[i + j] = m[i + j].clone() + b[i].clone() * c[j].clone();
+                }
+            }
+        }
+
+        // Carry propagation
+        for i in 0..LONG_WORD_SIZE {
+            let mut v = m[i].clone();
+            if i > 0 {
+                v += local.carry[i - 1].into();
+            }
+            v -= local.carry[i] * base.clone();
+            builder.assert_eq(local.product[i], v);
+        }
+
+        // Check result against a_lo and a_hi
+        for i in 0..WORD_SIZE {
+            builder
+                .when(local.is_real)
+                .assert_eq(local.product[i], local.a_lo[i]);
+            builder
+                .when(local.is_real)
+                .assert_eq(local.product[i + WORD_SIZE], local.a_hi[i]);
+        }
+
+        // Range checks
+        builder.slice_range_check_u16(&local.carry, local.is_real);
+        builder.slice_range_check_u8(&local.product, local.is_real);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        io::SP1Stdin,
+        rwasm::RwasmAir,
+        utils::{run_malicious_test, uni_stark_prove as prove, uni_stark_verify as verify},
+    };
+    use p3_baby_bear::BabyBear;
+    use rwasm_executor::{ExecutionRecord, Opcode};
+    use sp1_stark::{
+        air::MachineAir, baby_bear_poseidon2::BabyBearPoseidon2, chip_name, CpuProver,
+        MachineProver, StarkGenericConfig,
+    };
+
+    #[test]
+    fn generate_trace() {
+        let mut shard = ExecutionRecord::default();
+        let mut output = ExecutionRecord::default();
+        let b = 2u32;
+        let c = 3u32;
+        let result = (b as i32 as i64) * (c as i32 as i64);
+        shard.i64_events.push(I64AluEvent {
+            pc: 0,
+            opcode: Opcode::I32Mul64,
+            a: result as u32,
+            a_hi: (result >> 32) as u32,
+            b,
+            c,
+            code: Opcode::I32Mul64.code(),
+            res_hi_addr: 0,
+            res_hi_access: None,
+        });
+        let chip = Mul64Chip::default();
+        let trace: RowMajorMatrix<BabyBear> = chip.generate_trace(&shard, &mut output);
+        assert_eq!(trace.height(), 16); // Padded to a minimum of 16
+    }
+
+    #[test]
+    fn prove_babybear() {
+        let config = BabyBearPoseidon2::new();
+        let mut challenger = config.challenger();
+        let mut shard = ExecutionRecord::default();
+        let mut output = ExecutionRecord::default();
+
+        let test_cases = vec![
+            (0, 0),
+            (1, 0),
+            (u32::MAX, 0),
+            (1, 1),
+            (u32::MAX, 1),
+            (2, 3),
+            (u32::MAX, u32::MAX),
+            (1 << 20, 1 << 20),
+        ];
+
+        for (b, c) in test_cases {
+            let result = (b as i32 as i64) * (c as i32 as i64);
+            shard.i64_events.push(I64AluEvent {
+                pc: 0,
+                opcode: Opcode::I32Mul64,
+                a: result as u32,
+                a_hi: (result >> 32) as u32,
+                b,
+                c,
+                code: Opcode::I32Mul64.code(),
+                res_hi_addr: 0,
+                res_hi_access: None,
+            });
+        }
+
+        let chip = Mul64Chip::default();
+        let trace: RowMajorMatrix<BabyBear> = chip.generate_trace(&shard, &mut output);
+        let proof = prove::<BabyBearPoseidon2, _>(&config, &chip, &mut challenger, trace);
+
+        let mut challenger = config.challenger();
+        verify(&config, &chip, &mut challenger, &proof).unwrap();
+    }
+
+    #[test]
+    fn test_malicious_mul64() {
+        type P = CpuProver<BabyBearPoseidon2, RwasmAir<BabyBear>>;
+
+        let b = 12345u32;
+        let c = 54321u32;
+        let correct_res = (b as i32 as i64) * (c as i32 as i64);
+        let wrong_res = correct_res.wrapping_add(1);
+
+        let program = rwasm_executor::Program::from_instrs(vec![
+            Opcode::I32Const(b.into()),
+            Opcode::I32Const(c.into()),
+            Opcode::I32Mul64,
+            Opcode::Drop,
+            Opcode::Drop,
+        ]);
+        let stdin = SP1Stdin::new();
+
+        let malicious = move |prover: &P, record: &mut ExecutionRecord| {
+            let mut malicious_record = record.clone();
+            if let Some(event) = malicious_record
+                .i64_events
+                .iter_mut()
+                .find(|e| e.opcode == Opcode::I32Mul64)
+            {
+                event.a = wrong_res as u32;
+                event.a_hi = (wrong_res >> 32) as u32;
+            }
+            prover.generate_traces(&malicious_record)
+        };
+
+        let result = run_malicious_test::<P>(program, stdin, Box::new(malicious));
+        let chip_name = chip_name!(Mul64Chip, BabyBear);
+        assert!(result.is_err() && result.unwrap_err().is_constraints_failing(&chip_name));
+    }
+}

--- a/crates/rwasm/machine/src/alu/mul64/mod.rs
+++ b/crates/rwasm/machine/src/alu/mul64/mod.rs
@@ -210,6 +210,28 @@ impl Mul64Chip {
         cols.is_real = F::one();
         cols.is_mul64 = F::one();
 
+        // Send range checks for the original 4 bytes
+        blu.add_u8_range_checks(&b_word);
+        blu.add_u8_range_checks(&c_word);
+
+        // Send range checks for the extended upper 4 bytes
+        for i in WORD_SIZE..LONG_WORD_SIZE {
+            blu.add_byte_lookup_event(ByteLookupEvent {
+                opcode: ByteOpcode::U8Range,
+                a1: 0,
+                a2: 0,
+                b: b[i],
+                c: 0,
+            });
+            blu.add_byte_lookup_event(ByteLookupEvent {
+                opcode: ByteOpcode::U8Range,
+                a1: 0,
+                a2: 0,
+                b: c[i],
+                c: 0,
+            });
+        }
+
         blu.add_u16_range_checks(&carry.map(|x| x as u16));
         blu.add_u8_range_checks(&product.map(|x| x as u8));
     }
@@ -268,6 +290,28 @@ where
             }
             (b, c)
         };
+
+        // Send range checks for original b and c bytes
+        builder.slice_range_check_u8(&local.b.0, local.is_real);
+        builder.slice_range_check_u8(&local.c.0, local.is_real);
+
+        // Send range checks ONLY for the sign-extended upper 4 bytes
+        for i in WORD_SIZE..LONG_WORD_SIZE {
+            builder.send_byte(
+                ByteOpcode::U8Range.as_field::<AB::F>(),
+                AB::Expr::zero(),
+                b[i].clone(),
+                AB::Expr::zero(),
+                local.is_real,
+            );
+            builder.send_byte(
+                ByteOpcode::U8Range.as_field::<AB::F>(),
+                AB::Expr::zero(),
+                c[i].clone(),
+                AB::Expr::zero(),
+                local.is_real,
+            );
+        }
 
         // Uncarried product
         let mut m: Vec<AB::Expr> = vec![zero.clone(); LONG_WORD_SIZE];

--- a/crates/rwasm/machine/src/cpu/air/mod.rs
+++ b/crates/rwasm/machine/src/cpu/air/mod.rs
@@ -88,10 +88,11 @@ where
         // may witness an invalid word and write it to memory.
         // SAFETY: `local.is_real` is checked to be boolean in `eval_is_real`.
         builder.slice_range_check_u8(&local.op_res_access.access.value.0, local.is_real);
-        //range check the word value res_hi
-        /*builder
-        .when(local.instruction.is_64b_op)
-        .slice_range_check_u8(&local.op_res_hi_access.access.value.0, local.is_real);*/
+        builder.slice_range_check_u8(
+            &local.op_res_hi_access.access.value.0,
+            local.instruction.is_64b_op,
+        );
+
         // Check that the is_real flag is correct.
         self.eval_is_real(builder, local, next);
 

--- a/crates/rwasm/machine/src/cpu/air/mod.rs
+++ b/crates/rwasm/machine/src/cpu/air/mod.rs
@@ -523,6 +523,13 @@ impl CpuChip {
                 local.instruction.is_localget +
                 local.instruction.is_i32const,
         );
+        builder.eval_memory_access(
+            local.shard,
+            clk.clone() + AB::Expr::one(),
+            local.op_res_hi_addr.value::<AB>(),
+            &local.op_res_hi_access,
+            local.instruction.is_64b_op,
+        );
         self.eval_op_memory_increase_sp(builder, local, clk.clone());
         self.eval_op_memory_decrease_sp(builder, local, clk.clone());
         self.eval_binary_op_memory_sp(builder, local, clk.clone());
@@ -673,6 +680,15 @@ impl CpuChip {
                 local.sp + AB::Expr::from_canonical_u32(UNIT) + AB::Expr::from_canonical_u32(UNIT),
                 local.next_sp,
             );
+        // set constr for outputs when is_64b_op
+        builder.when(local.instruction.is_64b_op).assert_eq(local.sp, local.next_sp);
+        builder
+            .when(local.instruction.is_64b_op)
+            .assert_eq(local.op_res_hi_addr.value::<AB>(), local.next_sp);
+        builder.when(local.instruction.is_64b_op).assert_eq(
+            local.op_res_addr.value::<AB>(),
+            local.next_sp + AB::Expr::from_canonical_u32(UNIT),
+        );
     }
     pub(crate) fn eval_call<AB: SP1AirBuilder>(
         &self,

--- a/crates/rwasm/machine/src/cpu/air/mod.rs
+++ b/crates/rwasm/machine/src/cpu/air/mod.rs
@@ -112,11 +112,11 @@ impl CpuChip {
         local: &CpuCols<AB::Var>,
     ) {
         builder.send_64_instruction(
-            AB::Expr::zero(),
-            AB::Expr::zero(),
+            local.shard_to_send,
+            local.clk_to_send,
             local.pc,
             local.next_pc,
-            AB::Expr::zero(),
+            local.num_extra_cycles,
             local.instruction.opcode,
             local.op_res_val(),
             local.op_res_hi_val(),

--- a/crates/rwasm/machine/src/cpu/air/mod.rs
+++ b/crates/rwasm/machine/src/cpu/air/mod.rs
@@ -89,9 +89,9 @@ where
         // SAFETY: `local.is_real` is checked to be boolean in `eval_is_real`.
         builder.slice_range_check_u8(&local.op_res_access.access.value.0, local.is_real);
         //range check the word value res_hi
-        builder
+        /*builder
             .when(local.instruction.is_64b_op)
-            .slice_range_check_u8(&local.op_res_hi_access.access.value.0, local.is_real);
+            .slice_range_check_u8(&local.op_res_hi_access.access.value.0, local.is_real);*/
         // Check that the is_real flag is correct.
         self.eval_is_real(builder, local, next);
 
@@ -522,13 +522,6 @@ impl CpuChip {
                 local.instruction.is_i32load8u +
                 local.instruction.is_localget +
                 local.instruction.is_i32const,
-        );
-        builder.eval_memory_access(
-            local.shard,
-            clk.clone() + AB::Expr::one(),
-            local.op_res_hi_addr.value::<AB>(),
-            &local.op_res_hi_access,
-            local.instruction.is_64b_op,
         );
         self.eval_op_memory_increase_sp(builder, local, clk.clone());
         self.eval_op_memory_decrease_sp(builder, local, clk.clone());

--- a/crates/rwasm/machine/src/cpu/air/mod.rs
+++ b/crates/rwasm/machine/src/cpu/air/mod.rs
@@ -66,6 +66,7 @@ where
         builder.when(local.is_real).assert_eq(local.clk_to_send, expected_clk_to_send);
 
         self.eval_alu(builder, local);
+        self.eval_alu_i64(builder, local);
         self.eval_branching(builder, local);
         self.eval_call(builder, local, next);
         self.eval_memory(builder, local);
@@ -87,7 +88,10 @@ where
         // may witness an invalid word and write it to memory.
         // SAFETY: `local.is_real` is checked to be boolean in `eval_is_real`.
         builder.slice_range_check_u8(&local.op_res_access.access.value.0, local.is_real);
-
+        //range check the word value res_hi
+        builder
+            .when(local.instruction.is_64b_op)
+            .slice_range_check_u8(&local.op_res_hi_access.access.value.0, local.is_real);
         // Check that the is_real flag is correct.
         self.eval_is_real(builder, local, next);
 
@@ -102,6 +106,28 @@ where
 }
 
 impl CpuChip {
+    pub(crate) fn eval_alu_i64<AB: SP1AirBuilder>(
+        &self,
+        builder: &mut AB,
+        local: &CpuCols<AB::Var>,
+    ) {
+        builder.send_64_instruction(
+            AB::Expr::zero(),
+            AB::Expr::zero(),
+            local.pc,
+            local.next_pc,
+            AB::Expr::zero(),
+            local.instruction.opcode,
+            local.op_res_val(),
+            local.op_res_hi_val(),
+            local.op_arg1_val(),
+            local.op_arg2_val(),
+            AB::Expr::zero(),
+            AB::Expr::zero(),
+            AB::Expr::zero(),
+            local.instruction.is_64b_op,
+        );
+    }
     pub(crate) fn eval_alu<AB: SP1AirBuilder>(&self, builder: &mut AB, local: &CpuCols<AB::Var>) {
         // Send the instruction.
         // SAFETY: `local.is_real` is checked to be boolean in `eval_is_real`.

--- a/crates/rwasm/machine/src/cpu/air/mod.rs
+++ b/crates/rwasm/machine/src/cpu/air/mod.rs
@@ -90,8 +90,8 @@ where
         builder.slice_range_check_u8(&local.op_res_access.access.value.0, local.is_real);
         //range check the word value res_hi
         /*builder
-            .when(local.instruction.is_64b_op)
-            .slice_range_check_u8(&local.op_res_hi_access.access.value.0, local.is_real);*/
+        .when(local.instruction.is_64b_op)
+        .slice_range_check_u8(&local.op_res_hi_access.access.value.0, local.is_real);*/
         // Check that the is_real flag is correct.
         self.eval_is_real(builder, local, next);
 

--- a/crates/rwasm/machine/src/cpu/air/mod.rs
+++ b/crates/rwasm/machine/src/cpu/air/mod.rs
@@ -66,7 +66,7 @@ where
         builder.when(local.is_real).assert_eq(local.clk_to_send, expected_clk_to_send);
 
         self.eval_alu(builder, local);
-        self.eval_alu_i64(builder, local);
+        self.eval_alu_i64(builder, local, clk.clone());
         self.eval_branching(builder, local);
         self.eval_call(builder, local, next);
         self.eval_memory(builder, local);
@@ -100,6 +100,7 @@ where
         builder.when(not_real.clone()).assert_zero(AB::Expr::one() - local.is_syscall);
 
         StackAddressCols::<AB::F>::range_check(builder, local.op_res_addr);
+        StackAddressCols::<AB::F>::range_check(builder, local.op_res_hi_addr);
         StackAddressCols::<AB::F>::range_check(builder, local.op_arg1_addr);
         StackAddressCols::<AB::F>::range_check(builder, local.op_arg2_addr);
     }
@@ -110,6 +111,7 @@ impl CpuChip {
         &self,
         builder: &mut AB,
         local: &CpuCols<AB::Var>,
+        clk: AB::Expr,
     ) {
         builder.send_64_instruction(
             local.shard_to_send,
@@ -125,6 +127,14 @@ impl CpuChip {
             AB::Expr::zero(),
             AB::Expr::zero(),
             AB::Expr::zero(),
+            local.instruction.is_64b_op,
+        );
+
+        builder.eval_memory_access(
+            local.shard,
+            clk + AB::Expr::one(),
+            local.op_res_hi_addr.value::<AB>(),
+            &local.op_res_hi_access,
             local.instruction.is_64b_op,
         );
     }
@@ -521,7 +531,8 @@ impl CpuChip {
                 local.instruction.is_i32load8s +
                 local.instruction.is_i32load8u +
                 local.instruction.is_localget +
-                local.instruction.is_i32const,
+                local.instruction.is_i32const +
+                local.instruction.is_64b_op,
         );
         self.eval_op_memory_increase_sp(builder, local, clk.clone());
         self.eval_op_memory_decrease_sp(builder, local, clk.clone());
@@ -625,6 +636,7 @@ impl CpuChip {
             local.sp + AB::Expr::from_canonical_u8(4),
             &local.op_arg1_access,
             local.instruction.is_binary +
+                local.instruction.is_64b_op +
                 local.instruction.is_i32store +
                 local.instruction.is_i32store16 +
                 local.instruction.is_i32store8, // + local.instruction.is_table_grow,
@@ -636,6 +648,7 @@ impl CpuChip {
             local.sp,
             &local.op_arg2_access,
             local.instruction.is_binary +
+                local.instruction.is_64b_op +
                 local.instruction.is_i32store +
                 local.instruction.is_i32store16 +
                 local.instruction.is_i32store8, // + local.instruction.is_table_grow,

--- a/crates/rwasm/machine/src/cpu/columns/instruction.rs
+++ b/crates/rwasm/machine/src/cpu/columns/instruction.rs
@@ -69,6 +69,7 @@ pub struct InstructionCols<T> {
     pub is_callindirect: T,
     pub is_call: T,
     pub is_return: T,
+    pub is_64b_op: T,
 }
 
 impl<F: PrimeField> InstructionCols<F> {
@@ -81,6 +82,7 @@ impl<F: PrimeField> InstructionCols<F> {
         self.is_memory = F::from_bool(opcode.is_memory_instruction());
         self.is_branching = F::from_bool(opcode.is_branch_instruction());
         self.is_call_ins = F::from_bool(opcode.is_call_instruction());
+        self.is_64b_op = F::from_bool(opcode.is_64b_op());
         match opcode {
             Opcode::LocalGet(_) | Opcode::LocalSet(_) | Opcode::LocalTee(_) => {
                 self.is_local = F::one();
@@ -203,6 +205,7 @@ impl<T> IntoIterator for InstructionCols<T> {
             self.is_callinternal,
             self.is_return,
             self.is_skipped,
+            self.is_64b_op,
         ];
 
         columns.into_iter()

--- a/crates/rwasm/machine/src/cpu/columns/instruction.rs
+++ b/crates/rwasm/machine/src/cpu/columns/instruction.rs
@@ -156,7 +156,6 @@ impl<F: PrimeField> InstructionCols<F> {
             Opcode::SignatureCheck(_) => self.is_skipped = F::one(),
             Opcode::Drop => self.is_skipped = F::one(),
             Opcode::TableGrow(_) => self.is_table_grow = F::one(),
-
             _ => {}
         }
     }

--- a/crates/rwasm/machine/src/cpu/columns/mod.rs
+++ b/crates/rwasm/machine/src/cpu/columns/mod.rs
@@ -67,6 +67,7 @@ pub struct CpuCols<T: Copy> {
 
     /// Operand values, either from registers or immediate values.
     pub op_res_access: MemoryReadWriteCols<T>,
+    pub op_res_hi_access: MemoryReadWriteCols<T>,
     pub op_arg1_access: MemoryReadCols<T>,
     pub op_arg2_access: MemoryReadCols<T>,
 
@@ -74,6 +75,7 @@ pub struct CpuCols<T: Copy> {
     pub op_arg1_addr: StackAddressCols<T>,
     pub op_arg2_addr: StackAddressCols<T>,
     pub op_res_addr: StackAddressCols<T>,
+    pub op_res_hi_addr: StackAddressCols<T>,
 
     /// Selector to label whether this row is a non padded row.
     pub is_real: T,
@@ -83,6 +85,10 @@ impl<T: Copy> CpuCols<T> {
     /// Gets the value of the first operand.
     pub fn op_res_val(&self) -> Word<T> {
         *self.op_res_access.value()
+    }
+
+    pub fn op_res_hi_val(&self) -> Word<T> {
+        *self.op_res_hi_access.value()
     }
 
     /// Gets the value of the second operand.

--- a/crates/rwasm/machine/src/cpu/columns/mod.rs
+++ b/crates/rwasm/machine/src/cpu/columns/mod.rs
@@ -76,7 +76,6 @@ pub struct CpuCols<T: Copy> {
     pub op_arg2_addr: StackAddressCols<T>,
     pub op_res_addr: StackAddressCols<T>,
     pub op_res_hi_addr: StackAddressCols<T>,
-
     /// Selector to label whether this row is a non padded row.
     pub is_real: T,
 }

--- a/crates/rwasm/machine/src/cpu/trace.rs
+++ b/crates/rwasm/machine/src/cpu/trace.rs
@@ -140,6 +140,7 @@ impl CpuChip {
         );
         cols.is_syscall = F::from_bool(instruction.is_ecall_instruction());
         *cols.op_res_access.value_mut() = event.res.into();
+        *cols.op_res_hi_access.value_mut() = event.res_hi.into();
         *cols.op_arg1_access.value_mut() = event.arg1.into();
         *cols.op_arg2_access.value_mut() = event.arg2.into();
 
@@ -162,23 +163,39 @@ impl CpuChip {
             F::zero()
         };
 
-        // Populate memory accesses for a, b, and c.
-        if let Some(record) = event.res_record {
+        // Populate memory accesses for result (lo and optional hi for 64-bit ops).
+        if let Some(record_lo) = event.res_record {
             if instruction.is_ecall_instruction() {
-                // For ecall instructions, pass in a dummy byte lookup vector.  This syscall
-                // instruction chip also has a op_a_access field that will be
-                // populated and that will contribute to the byte lookup
-                // dependencies.
-                cols.op_res_access.populate(record, &mut Vec::new());
+                // For ecall instructions, pass in a dummy byte lookup vector.
+                cols.op_res_access.populate(record_lo, &mut Vec::new());
             } else {
-                cols.op_res_access.populate(record, blu_events);
+                // Lo write
+                cols.op_res_access.populate(record_lo, blu_events);
                 cols.op_res_addr.populate(
                     event.res_addr.unwrap().to_virtual_addr(),
                     blu_events,
                     true,
                 );
+                // Hi write for 64-bit ops
+                if instruction.is_64b_op() {
+                    if let Some(record_hi) = event.res_hi_record {
+                        cols.op_res_hi_access.populate(record_hi, blu_events);
+                        cols.op_res_hi_addr.populate(
+                            event.res_hi_addr.unwrap().to_virtual_addr(),
+                            blu_events,
+                            true,
+                        );
+                    } else {
+                        debug_assert!(
+                            false,
+                            "Missing res_hi_record for 64-bit op at pc={}",
+                            event.pc
+                        );
+                    }
+                }
             }
         }
+        // Populate arg1/arg2 memory reads.
         if let Some(MemoryRecordEnum::Read(record)) = event.arg1_record {
             cols.op_arg1_access.populate(record, blu_events);
             cols.op_arg1_addr.populate(
@@ -222,30 +239,29 @@ impl CpuChip {
             cols.call_data.call_sp_is_zero = F::from_bool(event.call_sp == 0);
         }
 
-        // Populate range checks for a.
-        let a_bytes = cols
-            .op_res_access
-            .access
-            .value
-            .0
-            .iter()
-            .map(|x| x.as_canonical_u32())
-            .collect::<Vec<_>>();
-        blu_events.add_byte_lookup_event(ByteLookupEvent {
-            opcode: ByteOpcode::U8Range,
-            a1: 0,
-            a2: 0,
-            b: a_bytes[0] as u8,
-            c: a_bytes[1] as u8,
-        });
-        blu_events.add_byte_lookup_event(ByteLookupEvent {
-            opcode: ByteOpcode::U8Range,
-            a1: 0,
-            a2: 0,
-            b: a_bytes[2] as u8,
-            c: a_bytes[3] as u8,
-        });
-
+        // Populate range checks for lo (and hi if 64-bit).
+        let checks = if instruction.is_64b_op() {
+            vec![cols.op_res_access, cols.op_res_hi_access]
+        } else {
+            vec![cols.op_res_access]
+        };
+        for col in checks {
+            let bytes = col.access.value.0.iter().map(|x| x.as_canonical_u32()).collect::<Vec<_>>();
+            blu_events.add_byte_lookup_event(ByteLookupEvent {
+                opcode: ByteOpcode::U8Range,
+                a1: 0,
+                a2: 0,
+                b: bytes[0] as u8,
+                c: bytes[1] as u8,
+            });
+            blu_events.add_byte_lookup_event(ByteLookupEvent {
+                opcode: ByteOpcode::U8Range,
+                a1: 0,
+                a2: 0,
+                b: bytes[2] as u8,
+                c: bytes[3] as u8,
+            });
+        }
         // Assert that the instruction is not a no-op.
         cols.is_real = F::one();
     }

--- a/crates/rwasm/machine/src/cpu/trace.rs
+++ b/crates/rwasm/machine/src/cpu/trace.rs
@@ -176,23 +176,19 @@ impl CpuChip {
                     blu_events,
                     true,
                 );
-                // Hi write for 64-bit ops
-                if instruction.is_64b_op() {
-                    if let Some(record_hi) = event.res_hi_record {
-                        cols.op_res_hi_access.populate(record_hi, blu_events);
-                        cols.op_res_hi_addr.populate(
-                            event.res_hi_addr.unwrap().to_virtual_addr(),
-                            blu_events,
-                            true,
-                        );
-                    } else {
-                        debug_assert!(
-                            false,
-                            "Missing res_hi_record for 64-bit op at pc={}",
-                            event.pc
-                        );
-                    }
-                }
+            }
+        }
+        if let Some(record_hi) = event.res_hi_record {
+            // Hi write for 64-bit ops
+            if instruction.is_64b_op() {
+                cols.op_res_hi_access.populate(record_hi, blu_events);
+                cols.op_res_hi_addr.populate(
+                    event.res_hi_addr.unwrap().to_virtual_addr(),
+                    blu_events,
+                    true,
+                );
+            } else {
+                debug_assert!(false, "Missing res_hi_record for 64-bit op at pc={}", event.pc);
             }
         }
         // Populate arg1/arg2 memory reads.

--- a/crates/rwasm/machine/src/rwasm/mod.rs
+++ b/crates/rwasm/machine/src/rwasm/mod.rs
@@ -30,7 +30,7 @@ use crate::{
 pub(crate) mod rwasm_chips {
     pub use crate::{
         alu::{
-            AddSubChip, BitwiseChip, DivRemChip, LtChip, MulChip, Mul64Chip, RotateChip, ShiftLeft,
+            AddSubChip, BitwiseChip, DivRemChip, LtChip, Mul64Chip, MulChip, RotateChip, ShiftLeft,
             ShiftRightChip,
         },
         bytes::ByteChip,

--- a/crates/rwasm/machine/src/rwasm/mod.rs
+++ b/crates/rwasm/machine/src/rwasm/mod.rs
@@ -30,7 +30,7 @@ use crate::{
 pub(crate) mod rwasm_chips {
     pub use crate::{
         alu::{
-            AddSubChip, BitwiseChip, DivRemChip, LtChip, MulChip, RotateChip, ShiftLeft,
+            AddSubChip, BitwiseChip, DivRemChip, LtChip, MulChip, Mul64Chip, RotateChip, ShiftLeft,
             ShiftRightChip,
         },
         bytes::ByteChip,
@@ -85,6 +85,8 @@ pub enum RwasmAir<F: PrimeField32> {
     Bitwise(BitwiseChip),
     /// An AIR for RISC-V Mul instruction.
     Mul(MulChip),
+    /// An AIR for RISC-V Mul64 instruction.
+    Mul64(Mul64Chip),
     /// An AIR for RISC-V Div and Rem instructions.
     DivRem(DivRemChip),
     /// An AIR for RISC-V Lt instruction.
@@ -376,6 +378,10 @@ impl<F: PrimeField32> RwasmAir<F> {
         costs.insert(mul.name(), mul.cost());
         chips.push(mul);
 
+        let mul64 = Chip::new(RwasmAir::Mul64(Mul64Chip::default()));
+        costs.insert(mul64.name(), mul64.cost());
+        chips.push(mul64);
+
         let shift_right = Chip::new(RwasmAir::ShiftRight(ShiftRightChip::default()));
         costs.insert(shift_right.name(), shift_right.cost());
         chips.push(shift_right);
@@ -459,6 +465,7 @@ impl<F: PrimeField32> RwasmAir<F> {
             RwasmAir::Add(AddSubChip::default()),
             RwasmAir::Bitwise(BitwiseChip::default()),
             RwasmAir::Mul(MulChip::default()),
+            RwasmAir::Mul64(Mul64Chip::default()),
             RwasmAir::DivRem(DivRemChip::default()),
             RwasmAir::Lt(LtChip::default()),
             RwasmAir::ShiftLeft(ShiftLeft::default()),
@@ -549,6 +556,7 @@ impl From<RwasmAirDiscriminants> for RwasmAirId {
             RwasmAirDiscriminants::Add => RwasmAirId::AddSub,
             RwasmAirDiscriminants::Bitwise => RwasmAirId::Bitwise,
             RwasmAirDiscriminants::Mul => RwasmAirId::Mul,
+            RwasmAirDiscriminants::Mul64 => RwasmAirId::Mul64,
             RwasmAirDiscriminants::DivRem => RwasmAirId::DivRem,
             RwasmAirDiscriminants::Lt => RwasmAirId::Lt,
             RwasmAirDiscriminants::ShiftLeft => RwasmAirId::ShiftLeft,

--- a/crates/rwasm/machine/src/rwasm/mod.rs
+++ b/crates/rwasm/machine/src/rwasm/mod.rs
@@ -30,8 +30,8 @@ use crate::{
 pub(crate) mod rwasm_chips {
     pub use crate::{
         alu::{
-            AddSubChip, BitwiseChip, DivRemChip, ExtendChip, LtChip, MulChip, RotateChip,
-            ShiftLeft, ShiftRightChip,Mul64Chip,
+            AddSubChip, BitwiseChip, DivRemChip, ExtendChip, LtChip, Mul64Chip, MulChip,
+            RotateChip, ShiftLeft, ShiftRightChip,
         },
         bytes::ByteChip,
         cpu::CpuChip,

--- a/crates/rwasm/machine/src/shape/mod.rs
+++ b/crates/rwasm/machine/src/shape/mod.rs
@@ -601,6 +601,9 @@ fn derive_cluster_from_maximal_shape(shape: &Shape<RwasmAirId>) -> ShapeCluster<
     let trialing_log_height = shape.log2_height(&RwasmAirId::Trailing);
     maybe_log2_heights.insert(RwasmAirId::Trailing, heuristic(trialing_log_height, 1));
 
+    let mul64_log_height = shape.log2_height(&RwasmAirId::Mul64);
+    maybe_log2_heights.insert(RwasmAirId::Mul64, heuristic(mul64_log_height, 1));
+
     let mul_log_height = shape.log2_height(&RwasmAirId::Mul);
     maybe_log2_heights.insert(RwasmAirId::Mul, heuristic(mul_log_height, 1));
 
@@ -731,6 +734,7 @@ pub mod tests {
             (RwasmAirId::AddSub, 10),
             (RwasmAirId::Bitwise, 10),
             (RwasmAirId::Mul, 10),
+            (RwasmAirId::Mul64, 12),
             (RwasmAirId::ShiftRight, 10),
             (RwasmAirId::ShiftLeft, 10),
             (RwasmAirId::Lt, 10),

--- a/crates/rwasm/machine/src/shape/mod.rs
+++ b/crates/rwasm/machine/src/shape/mod.rs
@@ -268,8 +268,8 @@ impl<F: PrimeField32> CoreShapeConfig<F> {
                     (air_id.to_string(), allowed_log2_height),
                     (
                         RwasmAir::<F>::SyscallPrecompile(SyscallChip::precompile()).name(),
-                        ((1 << allowed_log2_height)
-                            .div_ceil(&air_id.rows_per_event())
+                        (((1 << allowed_log2_height) as usize)
+                            .div_ceil(air_id.rows_per_event())
                             .next_power_of_two()
                             .ilog2() as usize)
                             .max(4),

--- a/crates/rwasm/machine/src/shape/shapeable.rs
+++ b/crates/rwasm/machine/src/shape/shapeable.rs
@@ -58,6 +58,7 @@ impl Shapeable for ExecutionRecord {
             (RwasmAirId::Rotate, self.rotate_events.len()),
             (RwasmAirId::Trailing, self.trailing_events.len()),
             (RwasmAirId::Mul, self.mul_events.len()),
+            (RwasmAirId::Mul64, self.i64_events.len()), //TODO
             (RwasmAirId::ShiftRight, self.shift_right_events.len()),
             (RwasmAirId::ShiftLeft, self.shift_left_events.len()),
             (RwasmAirId::Lt, self.lt_events.len()),

--- a/crates/rwasm/machine/src/shape/shapeable.rs
+++ b/crates/rwasm/machine/src/shape/shapeable.rs
@@ -58,7 +58,7 @@ impl Shapeable for ExecutionRecord {
             (RwasmAirId::Rotate, self.rotate_events.len()),
             (RwasmAirId::Trailing, self.trailing_events.len()),
             (RwasmAirId::Mul, self.mul_events.len()),
-            (RwasmAirId::Mul64, self.i64_events.len()), //TODO
+            (RwasmAirId::Mul64, self.i64_events.len()),
             (RwasmAirId::ShiftRight, self.shift_right_events.len()),
             (RwasmAirId::ShiftLeft, self.shift_left_events.len()),
             (RwasmAirId::Lt, self.lt_events.len()),

--- a/crates/rwasm/machine/src/shape/shapeable.rs
+++ b/crates/rwasm/machine/src/shape/shapeable.rs
@@ -59,7 +59,7 @@ impl Shapeable for ExecutionRecord {
             (RwasmAirId::Trailing, self.trailing_events.len()),
             (RwasmAirId::Extend, self.extend_events.len()),
             (RwasmAirId::Mul, self.mul_events.len()),
-            (RwasmAirId::Mul64, self.i64_events.len()),
+            (RwasmAirId::Mul64, self.mul64_events.len()),
             (RwasmAirId::ShiftRight, self.shift_right_events.len()),
             (RwasmAirId::ShiftLeft, self.shift_left_events.len()),
             (RwasmAirId::Lt, self.lt_events.len()),

--- a/crates/rwasm/prover/Cargo.toml
+++ b/crates/rwasm/prover/Cargo.toml
@@ -48,11 +48,10 @@ enum-map = { version = "2.7.3" }
 
 
 # rwasm
-rwasm = { git = "https://github.com/fluentlabs-xyz/rwasm.git", branch = "feat/tracing", features = [
+rwasm = { git = "https://github.com/fluentlabs-xyz/rwasm.git", branch = "feat/tracing-i64", features = [
     "std",
     "tracing",
 ] }
-
 
 [build-dependencies]
 downloader = { version = "0.2", default-features = false, features = [

--- a/crates/rwasm/prover/Cargo.toml
+++ b/crates/rwasm/prover/Cargo.toml
@@ -48,7 +48,7 @@ enum-map = { version = "2.7.3" }
 
 
 # rwasm
-rwasm = { git = "https://github.com/fluentlabs-xyz/rwasm.git", branch = "feat/tracing-i64", features = [
+rwasm = { git = "https://github.com/fluentlabs-xyz/rwasm.git", branch = "feat/tracing", features = [
     "std",
     "tracing",
 ] }

--- a/crates/rwasm/prover/Cargo.toml
+++ b/crates/rwasm/prover/Cargo.toml
@@ -16,7 +16,7 @@ sp1-recursion-compiler = { workspace = true }
 sp1-recursion-core = { workspace = true }
 sp1-recursion-circuit = { workspace = true }
 sp1-recursion-gnark-ffi = { workspace = true }
-rwasm-machine = { workspace = true, features = ["debug"] }
+rwasm-machine = { workspace = true}
 sp1-stark = { workspace = true }
 p3-symmetric = { workspace = true }
 rwasm-executor = { workspace = true }

--- a/crates/rwasm/prover/src/gas/model.rs
+++ b/crates/rwasm/prover/src/gas/model.rs
@@ -1,6 +1,6 @@
 use itertools::izip;
 
-pub const INPUT_SIZE: usize = 100; //TODO: find why this is 90
+pub const INPUT_SIZE: usize = 102; //TODO: find why this is 90
 
 pub fn predict(input: &[usize; INPUT_SIZE / 2]) -> f64 {
     let input = [input.map(|x| x as f64), input.map(|x| 2f64.powi(x.try_into().unwrap()))].concat();
@@ -128,6 +128,8 @@ pub(crate) const PARAMS: Params<INPUT_SIZE> = Params {
         0.0,
         0.0,
         0.0,
+        0.0,
+        0.0,
     ],
     std: [
         7.185413671836201,
@@ -230,6 +232,8 @@ pub(crate) const PARAMS: Params<INPUT_SIZE> = Params {
         0.0,
         0.0,
         0.0,
+        0.0,
+        0.0,
     ],
     coefs: [
         3.4394572520867,
@@ -321,6 +325,8 @@ pub(crate) const PARAMS: Params<INPUT_SIZE> = Params {
         60.515898660880275,
         88.22315498928933,
         296.047004079781,
+        0.0,
+        0.0,
         0.0,
         0.0,
         0.0,

--- a/crates/rwasm/prover/src/gas/model.rs
+++ b/crates/rwasm/prover/src/gas/model.rs
@@ -1,6 +1,6 @@
 use itertools::izip;
 
-pub const INPUT_SIZE: usize = 102; //TODO: find why this is 90
+pub const INPUT_SIZE: usize = 104; //TODO: find why this is 90
 
 pub fn predict(input: &[usize; INPUT_SIZE / 2]) -> f64 {
     let input = [input.map(|x| x as f64), input.map(|x| 2f64.powi(x.try_into().unwrap()))].concat();
@@ -130,6 +130,8 @@ pub(crate) const PARAMS: Params<INPUT_SIZE> = Params {
         0.0,
         0.0,
         0.0,
+        0.0,
+        0.0,
     ],
     std: [
         7.185413671836201,
@@ -234,6 +236,8 @@ pub(crate) const PARAMS: Params<INPUT_SIZE> = Params {
         0.0,
         0.0,
         0.0,
+        0.0,
+        0.0,
     ],
     coefs: [
         3.4394572520867,
@@ -325,6 +329,8 @@ pub(crate) const PARAMS: Params<INPUT_SIZE> = Params {
         60.515898660880275,
         88.22315498928933,
         296.047004079781,
+        0.0,
+        0.0,
         0.0,
         0.0,
         0.0,

--- a/crates/rwasm/prover/src/rwasmtest/mod.rs
+++ b/crates/rwasm/prover/src/rwasmtest/mod.rs
@@ -1,4 +1,5 @@
 mod comp;
+mod mul64;
 mod rotate;
 mod table_grow;
 mod table_init;

--- a/crates/rwasm/prover/src/rwasmtest/mul64.rs
+++ b/crates/rwasm/prover/src/rwasmtest/mul64.rs
@@ -4,8 +4,8 @@ use rwasm_executor::{Opcode, Program};
 #[test]
 pub fn test_base_case_for_mul64() {
     let ops = vec![
-        Opcode::I32Const(0x137_137.into()),
-        Opcode::I32Const(0x137_137.into()),
+        Opcode::I32Const(0x137_137u32.into()),
+        Opcode::I32Const(0x137_137u32.into()),
         Opcode::I32Mul64,
     ];
     let program = Program::from_instrs(ops);

--- a/crates/rwasm/prover/src/rwasmtest/mul64.rs
+++ b/crates/rwasm/prover/src/rwasmtest/mul64.rs
@@ -1,0 +1,21 @@
+use crate::rwasmtest::run_rwasm_prover;
+use rwasm_executor::{Opcode, Program};
+
+#[test]
+pub fn test_base_case_for_mul64() {
+    let ops = vec![
+        Opcode::I32Const(0x137_137.into()),
+        Opcode::I32Const(0x137_137.into()),
+        Opcode::I32Mul64,
+    ];
+    let program = Program::from_instrs(ops);
+    run_rwasm_prover(program);
+}
+
+#[test]
+pub fn test_base_case_for_mul32() {
+    let ops =
+        vec![Opcode::I32Const((-151515).into()), Opcode::I32Const((-8).into()), Opcode::I32Mul];
+    let program = Program::from_instrs(ops);
+    run_rwasm_prover(program);
+}

--- a/crates/stark/src/air/builder.rs
+++ b/crates/stark/src/air/builder.rs
@@ -254,6 +254,85 @@ pub trait InstructionAirBuilder: BaseAirBuilder {
             InteractionScope::Local,
         );
     }
+    /// Sends a 64-bit instruction to be processed.
+    #[allow(clippy::too_many_arguments)]
+    fn send_64_instruction(
+        &mut self,
+        shard: impl Into<Self::Expr> + Clone,
+        clk: impl Into<Self::Expr> + Clone,
+        pc: impl Into<Self::Expr>,
+        next_pc: impl Into<Self::Expr>,
+        num_extra_cycles: impl Into<Self::Expr>,
+        opcode: impl Into<Self::Expr>,
+        a: Word<impl Into<Self::Expr>>,
+        a_hi: Word<impl Into<Self::Expr>>,
+        b: Word<impl Into<Self::Expr>>,
+        c: Word<impl Into<Self::Expr>>,
+        is_memory: impl Into<Self::Expr>,
+        is_syscall: impl Into<Self::Expr>,
+        is_halt: impl Into<Self::Expr>,
+        multiplicity: impl Into<Self::Expr>,
+    ) {
+        let values = once(shard.into())
+            .chain(once(clk.into()))
+            .chain(once(pc.into()))
+            .chain(once(next_pc.into()))
+            .chain(once(num_extra_cycles.into()))
+            .chain(once(opcode.into()))
+            .chain(a.0.into_iter().map(Into::into))
+            .chain(a_hi.0.into_iter().map(Into::into))
+            .chain(b.0.into_iter().map(Into::into))
+            .chain(c.0.into_iter().map(Into::into))
+            .chain(once(is_memory.into()))
+            .chain(once(is_syscall.into()))
+            .chain(once(is_halt.into()))
+            .collect();
+
+        self.send(
+            AirInteraction::new(values, multiplicity.into(), InteractionKind::Instruction),
+            InteractionScope::Local,
+        );
+    }
+
+    /// Receives a 64-bit operation to be processed.
+    #[allow(clippy::too_many_arguments)]
+    fn receive_64_instruction(
+        &mut self,
+        shard: impl Into<Self::Expr> + Clone,
+        clk: impl Into<Self::Expr> + Clone,
+        pc: impl Into<Self::Expr>,
+        next_pc: impl Into<Self::Expr>,
+        num_extra_cycles: impl Into<Self::Expr>,
+        opcode: impl Into<Self::Expr>,
+        a: Word<impl Into<Self::Expr>>,
+        a_hi: Word<impl Into<Self::Expr>>,
+        b: Word<impl Into<Self::Expr>>,
+        c: Word<impl Into<Self::Expr>>,
+        is_memory: impl Into<Self::Expr>,
+        is_syscall: impl Into<Self::Expr>,
+        is_halt: impl Into<Self::Expr>,
+        multiplicity: impl Into<Self::Expr>,
+    ) {
+        let values = once(shard.into())
+            .chain(once(clk.into()))
+            .chain(once(pc.into()))
+            .chain(once(next_pc.into()))
+            .chain(once(num_extra_cycles.into()))
+            .chain(once(opcode.into()))
+            .chain(a.0.into_iter().map(Into::into))
+            .chain(a_hi.0.into_iter().map(Into::into))
+            .chain(b.0.into_iter().map(Into::into))
+            .chain(c.0.into_iter().map(Into::into))
+            .chain(once(is_memory.into()))
+            .chain(once(is_syscall.into()))
+            .chain(once(is_halt.into()))
+            .collect();
+
+        self.receive(
+            AirInteraction::new(values, multiplicity.into(), InteractionKind::Instruction),
+            InteractionScope::Local,
+        );
+    }
 
     /// Sends an syscall operation to be processed (with "ECALL" opcode).
     #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
This operation takes two 32-bit signed integers, multiplies them as 64-bit values, and pushes the full 64-bit result back to the stack as two 32-bit words (high and low).
The proof verification is handled within the Mul64Chip by constraining the following logic:

1. Zero Extension: The two 32-bit input operands (b and c) are zero-extended to 64-bit values. 
2. 32x32 Bit Multiplication: To prove the multiplication in a finite field, the operation is broken down using a schoolbook multiplication method:



## PR Checklist

- [X] Added Tests
- [X] Added Documentation
- [X] Breaking changes